### PR TITLE
Default time_step to 8ms

### DIFF
--- a/lua/neoscroll.lua
+++ b/lua/neoscroll.lua
@@ -199,6 +199,9 @@ neoscroll = {}
 -- move_cursor: scroll the window and the cursor simultaneously 
 -- time_step: time (in miliseconds) between one line scroll and the next one
 neoscroll.scroll = function(lines, move_cursor, time_step)
+    -- default time_step to 8ms
+    time_step = time_step or 8
+
     -- If lines is a fraction of the window transform it to lines
     if is_float(lines) then
         lines = get_lines_from_win_fraction(lines)


### PR DESCRIPTION
4e0b71e (Big refactor to generalise the code and add more scrolling stop options) broke this plugin for me, as I was using custom keymaps that didn't include a `time_step` in them. I fixed this on my own, but to save someone else some potential headache, I just went ahead and defaulted that to 8 in this PR.

I should definitely mention here that I didn't actually test this out locally, as I don't really know how to develop plugins locally. This just made logical sense to me based on what I know about lua.
