### PR TITLE
Fix error when guicursor is empty

### DIFF
--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -35,7 +35,9 @@ end
 local function hide_cursor()
     if vim.o.termguicolors then
         guicursor = vim.o.guicursor
-        vim.o.guicursor = guicursor .. ',a:NeoscrollHiddenCursor'
+	if guicursor ~= '' then
+            vim.o.guicursor = guicursor .. ',a:NeoscrollHiddenCursor'
+	end
     end
 end
 

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -33,18 +33,16 @@ end
 
 -- Hide cursor during scrolling for a better visual effect
 local function hide_cursor()
-    if vim.o.termguicolors then
+    if vim.o.termguicolors and vim.o.guicursor ~= '' then
         guicursor = vim.o.guicursor
-	if guicursor ~= '' then
-            vim.o.guicursor = guicursor .. ',a:NeoscrollHiddenCursor'
-	end
+        vim.o.guicursor = 'a:NeoscrollHiddenCursor'
     end
 end
 
 
 -- Restore hidden cursor during scrolling
 local function restore_cursor()
-    if vim.o.termguicolors then
+    if vim.o.termguicolors and vim.o.guicursor ~= '' then
         vim.o.guicursor = guicursor
     end
 end


### PR DESCRIPTION
Users may even opt out guicurosr option (i.e., set guicursor=) even when using true color terminal so only append cursor shape when it is not empty.