### PR TITLE
fix: use `go` for global scope instead of `o`. Fixes #35

### DIFF
--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -4,7 +4,7 @@ local so_scope
 if require('neoscroll.config').options.use_local_scrolloff then
     so_scope = 'wo'
 else
-    so_scope = 'o'
+    so_scope = 'go'
 end
 
 local scroll_timer = vim.loop.new_timer()


### PR DESCRIPTION
after restoring sessions, the global scrolloff is still wrong. (even after clearing all sessions)

You should use vim.go.scrolloff to get the correct value instead of the o scope.

The o scope is global-local, go scope is global only

Fixes #35 
Fixes #32
Fixes #33