### PR TITLE
fixing the example config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ require('neoscroll').setup({
     use_local_scrolloff = false, -- Use the local scope of scrolloff instead of the global scope
     respect_scrolloff = false,   -- Stop scrolling when the cursor reaches the scrolloff margin of the file
     cursor_scrolls_alone = true, -- The cursor will keep on scrolling even if the window cannot scroll further
-    easing_function = nil        -- Default easing function
+    easing_function = nil,        -- Default easing function
     pre_hook = nil,              -- Function to run before the scrolling animation starts
-    post_hook = nil              -- Function to run after the scrolling animation ends
+    post_hook = nil,              -- Function to run after the scrolling animation ends
 })
 ```
 


### PR DESCRIPTION
Hello, in this pull request I just fix the example config in the README.md, there was a missing comma.