### PR TITLE
feat: implement support for arbitrary winids

### DIFF
--- a/lua/neoscroll/config.lua
+++ b/lua/neoscroll/config.lua
@@ -1,87 +1,87 @@
 local config = {}
 
 config.options = {
-	mappings = { "<C-u>", "<C-d>", "<C-b>", "<C-f>", "<C-y>", "<C-e>", "zt", "zz", "zb" },
-	hide_cursor = true,
-	stop_eof = true,
-	respect_scrolloff = false,
-	cursor_scrolls_alone = true,
-	performance_mode = false,
+  mappings = { "<C-u>", "<C-d>", "<C-b>", "<C-f>", "<C-y>", "<C-e>", "zt", "zz", "zb" },
+  hide_cursor = true,
+  stop_eof = true,
+  respect_scrolloff = false,
+  cursor_scrolls_alone = true,
+  performance_mode = false,
 }
 
 function config.set_options(custom_opts)
-	config.options = vim.tbl_deep_extend("force", config.options, custom_opts or {})
+  config.options = vim.tbl_deep_extend("force", config.options, custom_opts or {})
 end
 
 config.easing_functions = {
-	quadratic = function(x)
-		return 1 - math.pow(1 - x, 1 / 2)
-	end,
-	cubic = function(x)
-		return 1 - math.pow(1 - x, 1 / 3)
-	end,
-	quartic = function(x)
-		return 1 - math.pow(1 - x, 1 / 4)
-	end,
-	quintic = function(x)
-		return 1 - math.pow(1 - x, 1 / 5)
-	end,
-	circular = function(x)
-		return 1 - math.pow(1 - x * x, 1 / 2)
-	end,
-	sine = function(x)
-		return 2 * math.asin(x) / math.pi
-	end,
+  quadratic = function(x)
+    return 1 - math.pow(1 - x, 1 / 2)
+  end,
+  cubic = function(x)
+    return 1 - math.pow(1 - x, 1 / 3)
+  end,
+  quartic = function(x)
+    return 1 - math.pow(1 - x, 1 / 4)
+  end,
+  quintic = function(x)
+    return 1 - math.pow(1 - x, 1 / 5)
+  end,
+  circular = function(x)
+    return 1 - math.pow(1 - x * x, 1 / 2)
+  end,
+  sine = function(x)
+    return 2 * math.asin(x) / math.pi
+  end,
 }
 
 local function generate_default_mappings(custom_mappings)
-	custom_mappings = custom_mappings and custom_mappings or {}
-	local defaults = {}
-	defaults["<C-u>"] = { "scroll", { "-vim.wo.scroll", "true", "250" } }
-	defaults["<C-d>"] = { "scroll", { "vim.wo.scroll", "true", "250" } }
-	defaults["<C-b>"] = { "scroll", { "-vim.api.nvim_win_get_height(0)", "true", "450" } }
-	defaults["<C-f>"] = { "scroll", { "vim.api.nvim_win_get_height(0)", "true", "450" } }
-	defaults["<C-y>"] = { "scroll", { "-0.10", "false", "100" } }
-	defaults["<C-e>"] = { "scroll", { "0.10", "false", "100" } }
-	defaults["zt"] = { "zt", { "250" } }
-	defaults["zz"] = { "zz", { "250" } }
-	defaults["zb"] = { "zb", { "250" } }
-	defaults["G"] = { "G", { "100" } }
-	defaults["gg"] = { "gg", { "100" } }
+  custom_mappings = custom_mappings and custom_mappings or {}
+  local defaults = {}
+  defaults["<C-u>"] = { "scroll", { "-vim.wo.scroll", "true", "250" } }
+  defaults["<C-d>"] = { "scroll", { "vim.wo.scroll", "true", "250" } }
+  defaults["<C-b>"] = { "scroll", { "-vim.api.nvim_win_get_height(0)", "true", "450" } }
+  defaults["<C-f>"] = { "scroll", { "vim.api.nvim_win_get_height(0)", "true", "450" } }
+  defaults["<C-y>"] = { "scroll", { "-0.10", "false", "100" } }
+  defaults["<C-e>"] = { "scroll", { "0.10", "false", "100" } }
+  defaults["zt"] = { "zt", { "250" } }
+  defaults["zz"] = { "zz", { "250" } }
+  defaults["zb"] = { "zb", { "250" } }
+  defaults["G"] = { "G", { "100" } }
+  defaults["gg"] = { "gg", { "100" } }
 
-	local t = {}
-	local keys = config.options.mappings
-	for i = 1, #keys do
-		if defaults[keys[i]] ~= nil then
-			t[keys[i]] = defaults[keys[i]]
-		end
-	end
-	return t
+  local t = {}
+  local keys = config.options.mappings
+  for i = 1, #keys do
+    if defaults[keys[i]] ~= nil then
+      t[keys[i]] = defaults[keys[i]]
+    end
+  end
+  return t
 end
 
 -- Helper function for mapping keys
 local function map_key(key, func, args)
-	local args_str = table.concat(args, ", ")
-	local prefix = [[lua require('neoscroll').]]
-	local lua_cmd = prefix .. func .. "(" .. args_str .. ")"
-	local cmd = "<cmd>" .. lua_cmd .. "<CR>"
-	local opts = { silent = true, noremap = true }
-	vim.api.nvim_set_keymap("n", key, cmd, opts)
-	vim.api.nvim_set_keymap("x", key, cmd, opts)
+  local args_str = table.concat(args, ", ")
+  local prefix = [[lua require('neoscroll').]]
+  local lua_cmd = prefix .. func .. "(" .. args_str .. ")"
+  local cmd = "<cmd>" .. lua_cmd .. "<CR>"
+  local opts = { silent = true, noremap = true }
+  vim.api.nvim_set_keymap("n", key, cmd, opts)
+  vim.api.nvim_set_keymap("x", key, cmd, opts)
 end
 
 -- Set mappings
 function config.set_mappings(custom_mappings)
-	if custom_mappings ~= nil then
-		for key, val in pairs(custom_mappings) do
-			map_key(key, val[1], val[2])
-		end
-	else
-		local default_mappings = generate_default_mappings()
-		for key, val in pairs(default_mappings) do
-			map_key(key, val[1], val[2])
-		end
-	end
+  if custom_mappings ~= nil then
+    for key, val in pairs(custom_mappings) do
+      map_key(key, val[1], val[2])
+    end
+  else
+    local default_mappings = generate_default_mappings()
+    for key, val in pairs(default_mappings) do
+      map_key(key, val[1], val[2])
+    end
+  end
 end
 
 return config

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -37,6 +37,17 @@ local WindowState = {
 }
 setmetatable(WindowState, WindowState)
 
+local function execute_nvim_cmd (cmd, options)
+  if vim.fn.has('nvim-0.8') == 1 then
+    return vim.api.nvim_cmd(cmd, options)
+  else
+    local command = string.format(
+      "%s%s %s", cmd.cmd, cmd.bang and "!" or "", table.concat(cmd.args)
+    )
+    return vim.api.nvim_exec(command, options.output or false)
+  end
+end
+
 -- excecute commands to scroll screen [and cursor] up/down one line
 -- The bang (!) `normal!` in normal ignores mappings
 local function scroll_up(state, scroll_window, scroll_cursor, n_repeat)
@@ -62,7 +73,7 @@ local function scroll_up(state, scroll_window, scroll_cursor, n_repeat)
   end
   utils.with_winid(state.winid, function()
     local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true, true)
-    vim.api.nvim_cmd({ cmd = "normal", bang = true, args = { escaped } }, { output = false })
+    execute_nvim_cmd({ cmd = "normal", bang = true, args = { escaped } }, { output = false })
   end)
 end
 
@@ -86,7 +97,7 @@ local function scroll_down(state, scroll_window, scroll_cursor, n_repeat)
   end
   utils.with_winid(state.winid, function()
     local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true, true)
-    vim.api.nvim_cmd({ cmd = "normal", bang = true, args = { escaped } }, { output = false })
+    execute_nvim_cmd({ cmd = "normal", bang = true, args = { escaped } }, { output = false })
   end)
 end
 

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -3,287 +3,314 @@ local utils = require("neoscroll.utils")
 local opts
 
 -- Highlight group to hide the cursor
-vim.api.nvim_exec([[
+vim.api.nvim_exec(
+	[[
 augroup custom_highlight
 autocmd!
 autocmd ColorScheme * highlight NeoscrollHiddenCursor gui=reverse blend=100
 augroup END
-]], true)
+]],
+	true
+)
 vim.cmd("highlight NeoscrollHiddenCursor gui=reverse blend=100")
 
 local WindowState = {
-  __index = function(state_table, winid)
-    assert(type(winid) == type(0) and winid >= 0,
-           "Expected a non-negative window id, got " .. tostring(winid))
-    local state = {
-      winid = winid,
-      scroll_timer = vim.loop.new_timer(),
-      target_line = 0,
-      relative_line = 0,
-      cursor_win_line = nil, -- set inside scroll()
-      scrolling = false,
-      continuous_scroll = false,
-      data = nil, -- set inside scroll()
-      scrolloff = utils.get_scrolloff(winid, opts.use_local_scrolloff)
-    }
-    state_table[winid] = state
-    return state
-  end
+	__index = function(state_table, winid)
+		assert(type(winid) == type(0) and winid >= 0,
+			"Expected a non-negative window id, got " .. tostring(winid)
+		)
+		local state = {
+			winid = winid,
+			scroll_timer = vim.loop.new_timer(),
+			target_line = 0,
+			relative_line = 0,
+			cursor_win_line = nil, -- set inside scroll()
+			scrolling = false,
+			continuous_scroll = false,
+			data = nil, -- set inside scroll()
+			scrolloff = utils.get_scrolloff(winid, opts.use_local_scrolloff)
+		}
+		state_table[winid] = state
+		return state
+	end
 }
 setmetatable(WindowState, WindowState)
 
 -- excecute commands to scroll screen [and cursor] up/down one line
 -- The bang (!) `normal!` in normal ignores mappings
 local function scroll_up(state, scroll_window, scroll_cursor, n_repeat)
-  local n = n_repeat == nil and 1 or n_repeat
-  local cursor_scroll_input = scroll_cursor and tostring(n) .. "gk" or ""
-  local window_scroll_input = scroll_window and tostring(n) .. [[<C-y>]] or ""
-  local data = state.data
-  local scroll_input
-  -- if scrolloff or window edge are going to move the cursor for you then only
-  -- scroll the window
-  if ((data.last_line_visible and data.win_lines_below_cursor ==
-      data.lines_below_cursor and data.lines_below_cursor <= state.scrolloff) or
-      data.win_lines_below_cursor == state.scrolloff) and scroll_window then
-    scroll_input = window_scroll_input
-  else
-    scroll_input = window_scroll_input .. cursor_scroll_input
-  end
-  utils.with_winid(state.winid, function()
-    local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true,
-                                                   true)
-    vim.api.nvim_cmd({cmd = "normal", bang = true, args = {escaped}},
-                     {output = false})
-  end)
+	local n = n_repeat == nil and 1 or n_repeat
+	local cursor_scroll_input = scroll_cursor and tostring(n) .. "gk" or ""
+	local window_scroll_input = scroll_window and tostring(n) .. [[<C-y>]] or ""
+	local data = state.data
+	local scroll_input
+	-- if scrolloff or window edge are going to move the cursor for you then only
+	-- scroll the window
+	if (
+			(
+					data.last_line_visible
+							and data.win_lines_below_cursor == data.lines_below_cursor
+							and data.lines_below_cursor <= state.scrolloff
+					) or data.win_lines_below_cursor == state.scrolloff
+			) and scroll_window
+	then
+		scroll_input = window_scroll_input
+	else
+		scroll_input = window_scroll_input .. cursor_scroll_input
+	end
+	utils.with_winid(state.winid, function()
+		local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true, true)
+		vim.api.nvim_cmd(
+			{ cmd = "normal", bang = true, args = { escaped } },
+			{ output = false }
+		)
+	end)
 end
 
 local function scroll_down(state, scroll_window, scroll_cursor, n_repeat)
-  local n = n_repeat == nil and 1 or n_repeat
-  local cursor_scroll_input = scroll_cursor and tostring(n) .. "gj" or ""
-  local window_scroll_input = scroll_window and tostring(n) .. [[<C-e>]] or ""
-  local data = state.data
-  local scroll_input
-  -- if scrolloff or window edge are going to move the cursor for you then only
-  -- scroll the window
-  if ((data.first_line_visible and data.win_lines_above_cursor <=
-      state.scrolloff) or data.win_lines_above_cursor <= state.scrolloff) and
-      scroll_window then
-    scroll_input = window_scroll_input
-  else
-    scroll_input = window_scroll_input .. cursor_scroll_input
-  end
-  utils.with_winid(state.winid, function()
-    local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true,
-                                                   true)
-    vim.api.nvim_cmd({cmd = "normal", bang = true, args = {escaped}},
-                     {output = false})
-  end)
+	local n = n_repeat == nil and 1 or n_repeat
+	local cursor_scroll_input = scroll_cursor and tostring(n) .. "gj" or ""
+	local window_scroll_input = scroll_window and tostring(n) .. [[<C-e>]] or ""
+	local data = state.data
+	local scroll_input
+	-- if scrolloff or window edge are going to move the cursor for you then only
+	-- scroll the window
+	if (
+			(data.first_line_visible and data.win_lines_above_cursor <= state.scrolloff)
+					or data.win_lines_above_cursor <= state.scrolloff
+			) and scroll_window
+	then
+		scroll_input = window_scroll_input
+	else
+		scroll_input = window_scroll_input .. cursor_scroll_input
+	end
+	utils.with_winid(state.winid, function()
+		local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true, true)
+		vim.api.nvim_cmd(
+			{ cmd = "normal", bang = true, args = { escaped } },
+			{ output = false }
+		)
+	end)
 end
 
 -- Window rules for when to stop scrolling
 local function window_reached_limit(state, move_cursor, direction)
-  local data = state.data
-  if data.last_line_visible and direction > 0 then
-    if move_cursor then
-      if opts.stop_eof and data.lines_below_cursor ==
-          data.win_lines_below_cursor then
-        return true
-      elseif opts.respect_scrolloff and data.lines_below_cursor <=
-          state.scrolloff then
-        return true
-      else
-        return data.lines_below_cursor == 0
-      end
-    else
-      return data.lines_below_cursor == 0 and data.win_lines_above_cursor == 0
-    end
-  elseif data.first_line_visible and direction < 0 then
-    return true
-  else
-    return false
-  end
+	local data = state.data
+	if data.last_line_visible and direction > 0 then
+		if move_cursor then
+			if opts.stop_eof and data.lines_below_cursor == data.win_lines_below_cursor then
+				return true
+			elseif opts.respect_scrolloff and data.lines_below_cursor <= state.scrolloff then
+				return true
+			else
+				return data.lines_below_cursor == 0
+			end
+		else
+			return data.lines_below_cursor == 0 and data.win_lines_above_cursor == 0
+		end
+	elseif data.first_line_visible and direction < 0 then
+		return true
+	else
+		return false
+	end
 end
 
 -- Cursor rules for when to stop scrolling
 local function cursor_reached_limit(state)
-  local data = state.data
-  if data.first_line_visible then
-    if opts.respect_scrolloff and data.win_lines_above_cursor <= state.scrolloff then
-      return true
-    end
-    return data.win_lines_above_cursor == 0
-  elseif data.last_line_visible then
-    if opts.respect_scrolloff and data.lines_below_cursor <= state.scrolloff then
-      return true
-    end
-    return data.lines_below_cursor == 0
-  end
+	local data = state.data
+	if data.first_line_visible then
+		if opts.respect_scrolloff and data.win_lines_above_cursor <= state.scrolloff then
+			return true
+		end
+		return data.win_lines_above_cursor == 0
+	elseif data.last_line_visible then
+		if opts.respect_scrolloff and data.lines_below_cursor <= state.scrolloff then
+			return true
+		end
+		return data.lines_below_cursor == 0
+	end
 end
 
 -- Check if the window and the cursor can be scrolled further
 local function who_scrolls(state, move_cursor, direction)
-  local data = state.data
-  local scroll_window, scroll_cursor
-  local half_window = math.floor(data.window_height / 2)
-  scroll_window = not window_reached_limit(state, move_cursor, direction)
-  if not move_cursor then
-    scroll_cursor = false
-  elseif scroll_window then
-    if state.scrolloff < half_window then
-      scroll_cursor = true
-    else
-      scroll_cursor = false
-    end
-  elseif opts.cursor_scrolls_alone then
-    scroll_cursor = not cursor_reached_limit(state)
-  else
-    scroll_cursor = false
-  end
-  return scroll_window, scroll_cursor
+	local data = state.data
+	local scroll_window, scroll_cursor
+	local half_window = math.floor(data.window_height / 2)
+	scroll_window = not window_reached_limit(state, move_cursor, direction)
+	if not move_cursor then
+		scroll_cursor = false
+	elseif scroll_window then
+		if state.scrolloff < half_window then
+			scroll_cursor = true
+		else
+			scroll_cursor = false
+		end
+	elseif opts.cursor_scrolls_alone then
+		scroll_cursor = not cursor_reached_limit(state)
+	else
+		scroll_cursor = false
+	end
+	return scroll_window, scroll_cursor
 end
 
 -- Scroll one line in the given direction
-local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor,
-    state)
-  if lines_to_scroll > 0 then
-    state.relative_line = state.relative_line + 1
-    scroll_down(state, scroll_window, scroll_cursor)
-    -- Correct for wrapped lines
-    local lines_behind = state.cursor_win_line - utils.getwinline(state.winid)
-    if scroll_cursor and scroll_window and lines_behind > 0 then
-      scroll_down(state, false, scroll_cursor, lines_behind)
-    end
-  else
-    state.relative_line = state.relative_line - 1
-    scroll_up(state, scroll_window, scroll_cursor)
-    -- Correct for wrapped lines
-    local lines_behind = utils.getwinline(state.winid) - state.cursor_win_line
-    if scroll_cursor and scroll_window and lines_behind > 0 then
-      scroll_up(state, false, scroll_cursor, lines_behind)
-    end
-  end
+local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, state)
+	if lines_to_scroll > 0 then
+		state.relative_line = state.relative_line + 1
+		scroll_down(state, scroll_window, scroll_cursor)
+		-- Correct for wrapped lines
+		local lines_behind = state.cursor_win_line - utils.getwinline(state.winid)
+		if scroll_cursor and scroll_window and lines_behind > 0 then
+			scroll_down(state, false, scroll_cursor, lines_behind)
+		end
+	else
+		state.relative_line = state.relative_line - 1
+		scroll_up(state, scroll_window, scroll_cursor)
+		-- Correct for wrapped lines
+		local lines_behind = utils.getwinline(state.winid) - state.cursor_win_line
+		if scroll_cursor and scroll_window and lines_behind > 0 then
+			scroll_up(state, false, scroll_cursor, lines_behind)
+		end
+	end
 end
 
 -- Scrolling constructor
 local function before_scrolling(winid, lines, move_cursor, info)
-  if opts.pre_hook ~= nil then opts.pre_hook(info) end
-  local state = WindowState[winid]
-  -- Start scrolling
-  state.scrolling = true
-  -- Hide cursor line
-  if opts.hide_cursor and move_cursor and winid == 0 then utils.hide_cursor() end
-  -- Performance mode
-  local performance_mode = vim.b.neoscroll_performance_mode or
-                               vim.g.neoscroll_performance_mode
-  if performance_mode and move_cursor then
-    if vim.g.loaded_nvim_treesitter then vim.cmd("TSBufDisable highlight") end
-    vim.bo.syntax = "OFF"
-  end
-  -- Assign number of lines to scroll
-  state.target_line = lines
+	if opts.pre_hook ~= nil then
+		opts.pre_hook(info)
+	end
+	local state = WindowState[winid]
+	-- Start scrolling
+	state.scrolling = true
+	-- Hide cursor line
+	if opts.hide_cursor and move_cursor and winid == 0 then
+		utils.hide_cursor()
+	end
+	-- Performance mode
+	local performance_mode = vim.b.neoscroll_performance_mode or vim.g.neoscroll_performance_mode
+	if performance_mode and move_cursor then
+		if vim.g.loaded_nvim_treesitter then
+			vim.cmd("TSBufDisable highlight")
+		end
+		vim.bo.syntax = "OFF"
+	end
+	-- Assign number of lines to scroll
+	state.target_line = lines
 end
 
 -- Scrolling destructor
 local function stop_scrolling(winid, move_cursor, info)
-  -- Note: winid may not exist anymore
-  if opts.hide_cursor == true and move_cursor and winid == 0 then
-    utils.unhide_cursor()
-  end
-  -- Performance mode
-  local performance_mode = vim.b.neoscroll_performance_mode or
-                               vim.g.neoscroll_performance_mode
-  if performance_mode and move_cursor then
-    vim.bo.syntax = "ON"
-    if vim.g.loaded_nvim_treesitter then vim.cmd("TSBufEnable highlight") end
-  end
-  if opts.post_hook ~= nil then opts.post_hook(info) end
-  local state = WindowState[winid]
-  -- window may be closed mid-scroll, and this would result in nil values
-  if state ~= nil then state.scroll_timer:stop() end
+	-- Note: winid may not exist anymore
+	if opts.hide_cursor == true and move_cursor and winid == 0 then
+		utils.unhide_cursor()
+	end
+	--Performance mode
+	local performance_mode = vim.b.neoscroll_performance_mode or vim.g.neoscroll_performance_mode
+	if performance_mode and move_cursor then
+		vim.bo.syntax = "ON"
+		if vim.g.loaded_nvim_treesitter then
+			vim.cmd("TSBufEnable highlight")
+		end
+	end
+	if opts.post_hook ~= nil then
+		opts.post_hook(info)
+	end
+	local state = WindowState[winid]
+	-- window may be closed mid-scroll, and this would result in nil values
+	if state ~= nil then
+		state.scroll_timer:stop()
+	end
 
-  WindowState[winid] = nil
+	WindowState[winid] = nil
 end
 
 local function compute_time_step(lines_to_scroll, lines, time, easing_function)
-  -- lines_to_scroll should always be positive
-  -- If there's less than one line to scroll time_step doesn't matter
-  if lines_to_scroll < 1 then return 1000 end
-  local lines_range = math.abs(lines)
-  local ef = config.easing_functions[easing_function]
-  local time_step
-  -- If not yet in range return average time-step
-  if not ef then
-    time_step = math.floor(time / (lines_range - 1) + 0.5)
-  elseif lines_to_scroll >= lines_range then
-    time_step = math.floor(time * ef(1 / lines_range) + 0.5)
-  else
-    local x1 = (lines_range - lines_to_scroll) / lines_range
-    local x2 = (lines_range - lines_to_scroll + 1) / lines_range
-    time_step = math.floor(time * (ef(x2) - ef(x1)) + 0.5)
-  end
-  if time_step == 0 then time_step = 1 end
-  return time_step
+	-- lines_to_scroll should always be positive
+	-- If there's less than one line to scroll time_step doesn't matter
+	if lines_to_scroll < 1 then
+		return 1000
+	end
+	local lines_range = math.abs(lines)
+	local ef = config.easing_functions[easing_function]
+	local time_step
+	-- If not yet in range return average time-step
+	if not ef then
+		time_step = math.floor(time / (lines_range - 1) + 0.5)
+	elseif lines_to_scroll >= lines_range then
+		time_step = math.floor(time * ef(1 / lines_range) + 0.5)
+	else
+		local x1 = (lines_range - lines_to_scroll) / lines_range
+		local x2 = (lines_range - lines_to_scroll + 1) / lines_range
+		time_step = math.floor(time * (ef(x2) - ef(x1)) + 0.5)
+	end
+	if time_step == 0 then
+		time_step = 1
+	end
+	return time_step
 end
 
 local neoscroll = {}
 
 local function callback_safe(fn, winid, move_cursor, info)
-  local function cb()
-    local ok, err = pcall(fn)
-    if not ok then
-      local ok2, err2 = pcall(stop_scrolling, winid, move_cursor, info)
-      if not ok2 then
-        local state = WindowState[winid]
-        if state ~= nil then WindowState[winid].scroll_timer:stop() end
-        -- something is horribly wrong if this happens
-        vim.api.nvim_echo({
-          {"neoscroll shutdown error:", "ErrorMsg"},
-          {tostring(err2), "ErrorMsg"}
-        }, true, {})
-      end
-      if type(err) ~= type("") or not err:lower():match("^.*invalid window id") then
-        vim.api.nvim_echo({
-          {"neoscroll scrolling error:", "ErrorMsg"},
-          {tostring(err), "ErrorMsg"}
-        }, true, {})
-      end
-    end
-  end
+	local function cb()
+		local ok, err = pcall(fn)
+		if not ok then
+			local ok2, err2 = pcall(stop_scrolling, winid, move_cursor, info)
+			if not ok2 then
+				local state = WindowState[winid]
+				if state ~= nil then
+					WindowState[winid].scroll_timer:stop()
+				end
+				-- something is horribly wrong if this happens
+				vim.api.nvim_echo({
+					{ "neoscroll shutdown error:", "ErrorMsg" },
+					{ tostring(err2), "ErrorMsg" },
+				}, true, {})
+			end
+			if type(err) ~= type("")
+					or not err:lower():match("^.*invalid window id") then
+				vim.api.nvim_echo({
+					{ "neoscroll scrolling error:", "ErrorMsg" },
+					{ tostring(err), "ErrorMsg" }
+				}, true, {})
+			end
+		end
+	end
 
-  return cb
+	return cb
 end
 
 -- Callback function triggered by scroll_timer
 local function scroll_callback(winid, lines, move_cursor, time, ef, info)
-  local state = WindowState[winid]
-  local lines_to_scroll = state.target_line - state.relative_line
+	local state = WindowState[winid]
+	local lines_to_scroll = state.target_line - state.relative_line
 
-  state.data = utils.get_data(winid)
-  local scroll_window, scroll_cursor
-  scroll_window, scroll_cursor =
-      who_scrolls(state, move_cursor, lines_to_scroll)
+	state.data = utils.get_data(winid)
+	local scroll_window, scroll_cursor
+	scroll_window, scroll_cursor = who_scrolls(
+		state, move_cursor, lines_to_scroll
+	)
 
-  if not scroll_window and not scroll_cursor then
-    stop_scrolling(winid, move_cursor, info)
-    return
-  end
+	if not scroll_window and not scroll_cursor then
+		stop_scrolling(winid, move_cursor, info)
+		return
+	end
 
-  if math.abs(lines_to_scroll) > 2 and ef then
-    local next_lines_to_scroll = math.abs(lines_to_scroll) - 2
-    local next_time_step = compute_time_step(next_lines_to_scroll, lines, time,
-                                             ef)
-    -- sets the repeat of the next cycle
-    state.scroll_timer:set_repeat(next_time_step)
-  end
-  if math.abs(lines_to_scroll) == 0 then
-    stop_scrolling(winid, move_cursor, info)
-    return
-  end
-  scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, state)
-  if math.abs(lines_to_scroll) == 1 then
-    stop_scrolling(winid, move_cursor, info)
-    return
-  end
+	if math.abs(lines_to_scroll) > 2 and ef then
+		local next_lines_to_scroll = math.abs(lines_to_scroll) - 2
+		local next_time_step = compute_time_step(next_lines_to_scroll, lines, time, ef)
+		-- sets the repeat of the next cycle
+		state.scroll_timer:set_repeat(next_time_step)
+	end
+	if math.abs(lines_to_scroll) == 0 then
+		stop_scrolling(winid, move_cursor, info)
+		return
+	end
+	scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, state)
+	if math.abs(lines_to_scroll) == 1 then
+		stop_scrolling(winid, move_cursor, info)
+		return
+	end
 end
 
 -- Scrolling function
@@ -291,170 +318,185 @@ end
 -- lines: number of lines to scroll or fraction of window to scroll
 -- move_cursor: scroll the window and the cursor simultaneously
 -- easing_function: name of the easing function to use for the scrolling animation
-function neoscroll.scroll_win(winid, lines, move_cursor, time, easing_function,
-    info)
-  local state = WindowState[winid]
-  state.winid = winid
-  -- If lines is a fraction of the window transform it to lines
-  if utils.is_float(lines) then
-    lines = utils.get_lines_from_win_fraction(winid, lines)
-  end
-  if lines == 0 then return end
+function neoscroll.scroll_win(winid, lines, move_cursor, time, easing_function, info)
+	local state = WindowState[winid]
+	state.winid = winid
+	-- If lines is a fraction of the window transform it to lines
+	if utils.is_float(lines) then
+		lines = utils.get_lines_from_win_fraction(winid, lines)
+	end
+	if lines == 0 then
+		return
+	end
 
-  -- If still scrolling just modify the amount of lines to scroll
-  -- If the scroll is in the opposite direction and
-  -- lines_to_scroll is longer than lines stop smoothly
-  if state.scrolling then
-    local lines_to_scroll = state.relative_line - state.target_line
-    local opposite_direction = lines_to_scroll * lines > 0
-    local long_scroll = math.abs(lines_to_scroll) - math.abs(lines) > 0
-    if opposite_direction and long_scroll then
-      state.target_line = state.relative_line - lines
-    elseif state.continuous_scroll then
-      state.target_line = state.relative_line + 2 * lines
-    elseif math.abs(lines_to_scroll) > math.abs(5 * lines) then
-      state.continuous_scroll = true
-      state.relative_line = state.target_line - 2 * lines
-    else
-      state.target_line = state.target_line + lines
-    end
+	-- If still scrolling just modify the amount of lines to scroll
+	-- If the scroll is in the opposite direction and
+	-- lines_to_scroll is longer than lines stop smoothly
+	if state.scrolling then
+		local lines_to_scroll = state.relative_line - state.target_line
+		local opposite_direction = lines_to_scroll * lines > 0
+		local long_scroll = math.abs(lines_to_scroll) - math.abs(lines) > 0
+		if opposite_direction and long_scroll then
+			state.target_line = state.relative_line - lines
+		elseif state.continuous_scroll then
+			state.target_line = state.relative_line + 2 * lines
+		elseif math.abs(lines_to_scroll) > math.abs(5 * lines) then
+			state.continuous_scroll = true
+			state.relative_line = state.target_line - 2 * lines
+		else
+			state.target_line = state.target_line + lines
+		end
 
-    return
-  end
+		return
+	end
 
-  -- Check if the window and the cursor are allowed to scroll in that direction
-  state.data = utils.get_data(winid)
-  local half_window = math.floor(state.data.window_height / 2)
-  if state.scrolloff >= half_window then
-    state.cursor_win_line = half_window
-  elseif state.data.win_lines_above_cursor <= state.scrolloff then
-    state.cursor_win_line = state.scrolloff + 1
-  elseif state.data.win_lines_below_cursor <= state.scrolloff then
-    state.cursor_win_line = state.data.window_height - state.scrolloff
-  else
-    state.cursor_win_line = state.data.cursor_win_line
-  end
+	-- Check if the window and the cursor are allowed to scroll in that direction
+	state.data = utils.get_data(winid)
+	local half_window = math.floor(state.data.window_height / 2)
+	if state.scrolloff >= half_window then
+		state.cursor_win_line = half_window
+	elseif state.data.win_lines_above_cursor <= state.scrolloff then
+		state.cursor_win_line = state.scrolloff + 1
+	elseif state.data.win_lines_below_cursor <= state.scrolloff then
+		state.cursor_win_line = state.data.window_height - state.scrolloff
+	else
+		state.cursor_win_line = state.data.cursor_win_line
+	end
 
-  local scroll_window, scroll_cursor = who_scrolls(state, move_cursor, lines)
-  -- If neither the window nor the cursor are allowed to scroll finish early
-  if not scroll_window and not scroll_cursor then return end
-  -- Preparation before scrolling starts
-  before_scrolling(winid, lines, move_cursor, info)
-  -- If easing function is not specified default to easing_function
-  local ef = easing_function and easing_function or opts.easing_function
+	local scroll_window, scroll_cursor = who_scrolls(state, move_cursor, lines)
+	-- If neither the window nor the cursor are allowed to scroll finish early
+	if not scroll_window and not scroll_cursor then
+		return
+	end
+	-- Preparation before scrolling starts
+	before_scrolling(winid, lines, move_cursor, info)
+	-- If easing function is not specified default to easing_function
+	local ef = easing_function and easing_function or opts.easing_function
 
-  local lines_to_scroll = math.abs(state.relative_line - state.target_line)
-  scroll_one_line(lines, scroll_window, scroll_cursor, state)
-  if lines_to_scroll == 1 then stop_scrolling(winid, move_cursor, info) end
-  local time_step = compute_time_step(lines_to_scroll, lines, time, ef)
-  local next_time_step = compute_time_step(lines_to_scroll - 1, lines, time, ef)
-  local next_next_time_step = compute_time_step(lines_to_scroll - 2, lines,
-                                                time, ef)
-  -- Scroll the first line
+	local lines_to_scroll = math.abs(state.relative_line - state.target_line)
+	scroll_one_line(lines, scroll_window, scroll_cursor, state)
+	if lines_to_scroll == 1 then
+		stop_scrolling(winid, move_cursor, info)
+	end
+	local time_step = compute_time_step(lines_to_scroll, lines, time, ef)
+	local next_time_step = compute_time_step(lines_to_scroll - 1, lines, time, ef)
+	local next_next_time_step = compute_time_step(lines_to_scroll - 2, lines, time, ef)
+	-- Scroll the first line
 
-  -- Start timer to scroll the rest of the lines
-  state.scroll_timer:start(time_step, next_time_step,
-                           vim.schedule_wrap(
-      callback_safe(function()
-        scroll_callback(winid, lines, move_cursor, time, ef, info)
-      end, winid, move_cursor, info)))
-  state.scroll_timer:set_repeat(next_next_time_step)
+	-- Start timer to scroll the rest of the lines
+	state.scroll_timer:start(
+		time_step, next_time_step,
+		vim.schedule_wrap(
+			callback_safe(function()
+				scroll_callback(winid, lines, move_cursor, time, ef, info)
+			end,
+				winid,
+				move_cursor,
+				info
+			)
+		)
+	)
+	state.scroll_timer:set_repeat(next_next_time_step)
 end
 
-function neoscroll.scroll(...) return neoscroll.scroll_win(0, ...) end
+function neoscroll.scroll(...)
+	return neoscroll.scroll_win(0, ...)
+end
 
 -- Wrapper for zt
 function neoscroll.zt_win(winid, half_screen_time, easing, info)
-  local window_height = vim.api.nvim_win_get_height(winid)
-  -- TODO figure out why this -2 is needed (also needed in master)
-  --      one guess: because scrolloff is -1
-  local win_lines_above_cursor = utils.getwinline(winid) - 1
-  -- Temporary fix for garbage values in local scrolloff when not set
-  local lines = win_lines_above_cursor -
-                    utils.get_scrolloff(winid, opts.use_local_scrolloff)
-  if lines == 0 then return end
-  local corrected_time = math.floor(half_screen_time *
-                                        (math.abs(lines) / (window_height / 2)) +
-                                        0.5)
-  neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
+	local window_height = vim.api.nvim_win_get_height(winid)
+	-- TODO figure out why this -2 is needed (also needed in master)
+	--      one guess: because scrolloff is -1
+	local win_lines_above_cursor = utils.getwinline(winid) - 1
+	-- Temporary fix for garbage values in local scrolloff when not set
+	local lines = win_lines_above_cursor - utils.get_scrolloff(winid, opts.use_local_scrolloff)
+	if lines == 0 then
+		return
+	end
+	local corrected_time = math.floor(
+		half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5
+	)
+	neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
 end
 
 function neoscroll.zt(half_screen_time, easing, info)
-  return neoscroll.zt_win(0, half_screen_time, easing, info)
+	return neoscroll.zt_win(0, half_screen_time, easing, info)
 end
 
 -- Wrapper for zz
 function neoscroll.zz_win(winid, half_screen_time, easing, info)
-  local window_height = vim.api.nvim_win_get_height(winid)
-  local lines = utils.getwinline(winid) - math.floor(window_height / 2 + 1)
-  if lines == 0 then return end
-  local corrected_time = math.floor(half_screen_time *
-                                        (math.abs(lines) / (window_height / 2)) +
-                                        0.5)
-  neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
+	local window_height = vim.api.nvim_win_get_height(winid)
+	local lines = utils.getwinline(winid) - math.floor(window_height / 2 + 1)
+	if lines == 0 then
+		return
+	end
+	local corrected_time = math.floor(
+		half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5
+	)
+	neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
 end
 
 function neoscroll.zz(half_screen_time, easing, info)
-  return neoscroll.zz_win(0, half_screen_time, easing, info)
+	return neoscroll.zz_win(0, half_screen_time, easing, info)
 end
 
 -- Wrapper for zb
 function neoscroll.zb_win(winid, half_screen_time, easing, info)
-  local window_height = vim.api.nvim_win_get_height(winid)
-  local lines_below_cursor = window_height - utils.getwinline(winid)
-  -- Temporary fix for garbage values in local scrolloff when not set
-  local lines = -lines_below_cursor +
-                    utils.get_scrolloff(winid, opts.use_local_scrolloff)
-  if lines == 0 then return end
-  local corrected_time = math.floor(half_screen_time *
-                                        (math.abs(lines) / (window_height / 2)) +
-                                        0.5)
-  neoscroll.scroll(lines, false, corrected_time, easing, info)
+	local window_height = vim.api.nvim_win_get_height(winid)
+	local lines_below_cursor = window_height - utils.getwinline(winid)
+	-- Temporary fix for garbage values in local scrolloff when not set
+	local lines = -lines_below_cursor + utils.get_scrolloff(winid, opts.use_local_scrolloff)
+	if lines == 0 then
+		return
+	end
+	local corrected_time = math.floor(
+		half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5
+	)
+	neoscroll.scroll(lines, false, corrected_time, easing, info)
 end
 
 function neoscroll.zb(half_screen_time, easing, info)
-  return neoscroll.zb_win(0, half_screen_time, easing, info)
+	return neoscroll.zb_win(0, half_screen_time, easing, info)
 end
 
 function neoscroll.G_win(winid, half_screen_time, easing, info)
-  local lines = utils.get_lines_below(winid, vim.fn.line("w$", winid))
-  local window_height = vim.api.nvim_win_get_height(winid)
-  local corrected_time = math.floor(half_screen_time *
-                                        (math.abs(lines) / (window_height / 2)) +
-                                        0.5)
-  neoscroll.scroll_win(winid, lines, true, corrected_time, easing, info)
+	local lines = utils.get_lines_below(winid, utils.getline(winid, "w$"))
+	local window_height = vim.api.nvim_win_get_height(winid)
+	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
+	neoscroll.scroll(lines, true, corrected_time, easing, { G = true })
 end
 
 function neoscroll.G(half_screen_time, easing, info)
-  return neoscroll.G_win(0, half_screen_time, easing, info)
+	return neoscroll.G_win(0, half_screen_time, easing, info)
 end
 
 function neoscroll.gg_win(winid, half_screen_time, easing, info)
-  local lines = utils.get_lines_above(winid, vim.fn.line("w0", winid))
-  local window_height = vim.api.nvim_win_get_height(winid)
-  local cursor_win_line = utils.getwinline(winid)
-  lines = -lines - cursor_win_line
-  local corrected_time = math.floor(half_screen_time *
-                                        (math.abs(lines) / (window_height / 2)) +
-                                        0.5)
-  neoscroll.scroll_win(winid, lines, true, corrected_time, easing, info)
+	local lines = utils.get_lines_above(winid, utils.getline(winid, "w0"))
+	local window_height = vim.api.nvim_win_get_height(winid)
+	local cursor_win_line = utils.getwinline(winid)
+	lines = -lines - cursor_win_line
+	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
+	neoscroll.scroll_win(winid, lines, true, corrected_time, easing, info)
 end
 
 function neoscroll.gg(half_screen_time, easing, info)
-  return neoscroll.gg_win(0, half_screen_time, easing, info)
+	return neoscroll.gg_win(0, half_screen_time, easing, info)
 end
 
 function neoscroll.setup(custom_opts)
-  config.set_options(custom_opts)
-  opts = require("neoscroll.config").options
-  require("neoscroll.config").set_mappings()
-  vim.cmd("command! NeoscrollEnablePM let b:neoscroll_performance_mode = v:true")
-  vim.cmd("command! NeoscrollDisablePM let b:neoscroll_performance_mode = v:false")
-  vim.cmd("command! NeoscrollEnableBufferPM let b:neoscroll_performance_mode = v:true")
-  vim.cmd("command! NeoscrollDisableBufferPM let b:neoscroll_performance_mode = v:false")
-  vim.cmd("command! NeoscrollEnableGlobalPM let g:neoscroll_performance_mode = v:true")
-  vim.cmd("command! NeoscrollDisablGlobalePM let g:neoscroll_performance_mode = v:false")
-  if opts.performance_mode then vim.g.neoscroll_performance_mode = true end
+	config.set_options(custom_opts)
+	opts = require("neoscroll.config").options
+	require("neoscroll.config").set_mappings()
+	vim.cmd("command! NeoscrollEnablePM let b:neoscroll_performance_mode = v:true")
+	vim.cmd("command! NeoscrollDisablePM let b:neoscroll_performance_mode = v:false")
+	vim.cmd("command! NeoscrollEnableBufferPM let b:neoscroll_performance_mode = v:true")
+	vim.cmd("command! NeoscrollDisableBufferPM let b:neoscroll_performance_mode = v:false")
+	vim.cmd("command! NeoscrollEnableGlobalPM let g:neoscroll_performance_mode = v:true")
+	vim.cmd("command! NeoscrollDisablGlobalePM let g:neoscroll_performance_mode = v:false")
+	if opts.performance_mode then
+		vim.g.neoscroll_performance_mode = true
+	end
 end
 
 return neoscroll

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -1,386 +1,460 @@
 local config = require("neoscroll.config")
 local utils = require("neoscroll.utils")
 local opts
-local so_scope
 
-local scroll_timer = vim.loop.new_timer()
-local target_line = 0
-local relative_line = 0
-local cursor_win_line
-local scrolling = false
-local continuous_scroll = false
 -- Highlight group to hide the cursor
-vim.api.nvim_exec(
-	[[
+vim.api.nvim_exec([[
 augroup custom_highlight
 autocmd!
 autocmd ColorScheme * highlight NeoscrollHiddenCursor gui=reverse blend=100
 augroup END
-]],
-	true
-)
+]], true)
 vim.cmd("highlight NeoscrollHiddenCursor gui=reverse blend=100")
 
+local WindowState = {
+  __index = function(state_table, winid)
+    assert(type(winid) == type(0) and winid >= 0,
+           "Expected a non-negative window id, got " .. tostring(winid))
+    local state = {
+      winid = winid,
+      scroll_timer = vim.loop.new_timer(),
+      target_line = 0,
+      relative_line = 0,
+      cursor_win_line = nil, -- set inside scroll()
+      scrolling = false,
+      continuous_scroll = false,
+      data = nil, -- set inside scroll()
+      scrolloff = utils.get_scrolloff(winid, opts.use_local_scrolloff)
+    }
+    state_table[winid] = state
+    return state
+  end
+}
+setmetatable(WindowState, WindowState)
+
 -- excecute commands to scroll screen [and cursor] up/down one line
--- `execute` is necessary to allow the use of special characters like <C-y>
 -- The bang (!) `normal!` in normal ignores mappings
-local function scroll_up(data, scroll_window, scroll_cursor, n_repeat)
-	local n = n_repeat == nil and 1 or n_repeat
-	local cursor_scroll_input = scroll_cursor and string.rep("gk", n) or ""
-	local window_scroll_input = scroll_window and [[\<C-y>]] or ""
-	local scroll_input
+local function scroll_up(state, scroll_window, scroll_cursor, n_repeat)
+  local n = n_repeat == nil and 1 or n_repeat
+  local cursor_scroll_input = scroll_cursor and tostring(n) .. "gk" or ""
+  local window_scroll_input = scroll_window and tostring(n) .. [[<C-y>]] or ""
+  local data = state.data
+  local scroll_input
   -- if scrolloff or window edge are going to move the cursor for you then only
   -- scroll the window
-  if
-		(
-			(
-				data.last_line_visible
-				and data.win_lines_below_cursor == data.lines_below_cursor
-				and data.lines_below_cursor <= utils.get_scrolloff()
-			) or data.win_lines_below_cursor == utils.get_scrolloff()
-		) and scroll_window
-	then
-		scroll_input = window_scroll_input
-	else
-		scroll_input = window_scroll_input .. cursor_scroll_input
-	end
-	return [[exec "normal! ]] .. scroll_input .. [["]]
+  if ((data.last_line_visible and data.win_lines_below_cursor ==
+      data.lines_below_cursor and data.lines_below_cursor <= state.scrolloff) or
+      data.win_lines_below_cursor == state.scrolloff) and scroll_window then
+    scroll_input = window_scroll_input
+  else
+    scroll_input = window_scroll_input .. cursor_scroll_input
+  end
+  utils.with_winid(state.winid, function()
+    local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true,
+                                                   true)
+    vim.api.nvim_cmd({cmd = "normal", bang = true, args = {escaped}},
+                     {output = false})
+  end)
 end
 
-local function scroll_down(data, scroll_window, scroll_cursor, n_repeat)
-	local n = n_repeat == nil and 1 or n_repeat
-	local cursor_scroll_input = scroll_cursor and string.rep("gj", n) or ""
-	local window_scroll_input = scroll_window and [[\<C-e>]] or ""
-	local scroll_input
+local function scroll_down(state, scroll_window, scroll_cursor, n_repeat)
+  local n = n_repeat == nil and 1 or n_repeat
+  local cursor_scroll_input = scroll_cursor and tostring(n) .. "gj" or ""
+  local window_scroll_input = scroll_window and tostring(n) .. [[<C-e>]] or ""
+  local data = state.data
+  local scroll_input
   -- if scrolloff or window edge are going to move the cursor for you then only
   -- scroll the window
-	if
-		(
-			(data.first_line_visible and data.win_lines_above_cursor <= utils.get_scrolloff())
-			or data.win_lines_above_cursor <= utils.get_scrolloff()
-		) and scroll_window
-	then
-		scroll_input = window_scroll_input
-	else
-		scroll_input = window_scroll_input .. cursor_scroll_input
-	end
-	return [[exec "normal! ]] .. scroll_input .. [["]]
+  if ((data.first_line_visible and data.win_lines_above_cursor <=
+      state.scrolloff) or data.win_lines_above_cursor <= state.scrolloff) and
+      scroll_window then
+    scroll_input = window_scroll_input
+  else
+    scroll_input = window_scroll_input .. cursor_scroll_input
+  end
+  utils.with_winid(state.winid, function()
+    local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true,
+                                                   true)
+    vim.api.nvim_cmd({cmd = "normal", bang = true, args = {escaped}},
+                     {output = false})
+  end)
 end
 
 -- Window rules for when to stop scrolling
-local function window_reached_limit(data, move_cursor, direction)
-	if data.last_line_visible and direction > 0 then
-		if move_cursor then
-			if opts.stop_eof and data.lines_below_cursor == data.win_lines_below_cursor then
-				return true
-			elseif opts.respect_scrolloff and data.lines_below_cursor <= utils.get_scrolloff() then
-				return true
-			else
-				return data.lines_below_cursor == 0
-			end
-		else
-			return data.lines_below_cursor == 0 and data.win_lines_above_cursor == 0
-		end
-	elseif data.first_line_visible and direction < 0 then
-		return true
-	else
-		return false
-	end
+local function window_reached_limit(state, move_cursor, direction)
+  local data = state.data
+  if data.last_line_visible and direction > 0 then
+    if move_cursor then
+      if opts.stop_eof and data.lines_below_cursor ==
+          data.win_lines_below_cursor then
+        return true
+      elseif opts.respect_scrolloff and data.lines_below_cursor <=
+          state.scrolloff then
+        return true
+      else
+        return data.lines_below_cursor == 0
+      end
+    else
+      return data.lines_below_cursor == 0 and data.win_lines_above_cursor == 0
+    end
+  elseif data.first_line_visible and direction < 0 then
+    return true
+  else
+    return false
+  end
 end
 
 -- Cursor rules for when to stop scrolling
-local function cursor_reached_limit(data)
-	if data.first_line_visible then
-		if opts.respect_scrolloff and data.win_lines_above_cursor <= utils.get_scrolloff() then
-			return true
-		end
-		return data.win_lines_above_cursor == 0
-	elseif data.last_line_visible then
-		if opts.respect_scrolloff and data.lines_below_cursor <= utils.get_scrolloff() then
-			return true
-		end
-		return data.lines_below_cursor == 0
-	end
+local function cursor_reached_limit(state)
+  local data = state.data
+  if data.first_line_visible then
+    if opts.respect_scrolloff and data.win_lines_above_cursor <= state.scrolloff then
+      return true
+    end
+    return data.win_lines_above_cursor == 0
+  elseif data.last_line_visible then
+    if opts.respect_scrolloff and data.lines_below_cursor <= state.scrolloff then
+      return true
+    end
+    return data.lines_below_cursor == 0
+  end
 end
 
 -- Check if the window and the cursor can be scrolled further
-local function who_scrolls(data, move_cursor, direction)
-	local scroll_window, scroll_cursor
-  local half_window = math.floor(data.window_height/2)
-	scroll_window = not window_reached_limit(data, move_cursor, direction)
-	if not move_cursor then
-		scroll_cursor = false
-	elseif scroll_window then
-    if utils.get_scrolloff() < half_window then
+local function who_scrolls(state, move_cursor, direction)
+  local data = state.data
+  local scroll_window, scroll_cursor
+  local half_window = math.floor(data.window_height / 2)
+  scroll_window = not window_reached_limit(state, move_cursor, direction)
+  if not move_cursor then
+    scroll_cursor = false
+  elseif scroll_window then
+    if state.scrolloff < half_window then
       scroll_cursor = true
     else
       scroll_cursor = false
     end
-	elseif opts.cursor_scrolls_alone then
-		scroll_cursor = not cursor_reached_limit(data)
-	else
-		scroll_cursor = false
-	end
-	return scroll_window, scroll_cursor
+  elseif opts.cursor_scrolls_alone then
+    scroll_cursor = not cursor_reached_limit(state)
+  else
+    scroll_cursor = false
+  end
+  return scroll_window, scroll_cursor
 end
 
 -- Scroll one line in the given direction
-local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, data)
-	if lines_to_scroll > 0 then
-		relative_line = relative_line + 1
-		vim.cmd(scroll_down(data, scroll_window, scroll_cursor))
-		-- Correct for wrapped lines
-		local lines_behind = cursor_win_line - vim.fn.winline()
-		if scroll_cursor and scroll_window and lines_behind > 0 then
-			vim.cmd(scroll_down(data, false, scroll_cursor, lines_behind))
-		end
-	else
-		relative_line = relative_line - 1
-		vim.cmd(scroll_up(data, scroll_window, scroll_cursor))
-		-- Correct for wrapped lines
-		local lines_behind = vim.fn.winline() - cursor_win_line
-		if scroll_cursor and scroll_window and lines_behind > 0 then
-			vim.cmd(scroll_up(data, false, scroll_cursor, lines_behind))
-		end
-	end
+local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor,
+    state)
+  if lines_to_scroll > 0 then
+    state.relative_line = state.relative_line + 1
+    scroll_down(state, scroll_window, scroll_cursor)
+    -- Correct for wrapped lines
+    local lines_behind = state.cursor_win_line - utils.getwinline(state.winid)
+    if scroll_cursor and scroll_window and lines_behind > 0 then
+      scroll_down(state, false, scroll_cursor, lines_behind)
+    end
+  else
+    state.relative_line = state.relative_line - 1
+    scroll_up(state, scroll_window, scroll_cursor)
+    -- Correct for wrapped lines
+    local lines_behind = utils.getwinline(state.winid) - state.cursor_win_line
+    if scroll_cursor and scroll_window and lines_behind > 0 then
+      scroll_up(state, false, scroll_cursor, lines_behind)
+    end
+  end
 end
 
 -- Scrolling constructor
-local function before_scrolling(lines, move_cursor, info)
-	if opts.pre_hook ~= nil then
-		opts.pre_hook(info)
-	end
-	-- Start scrolling
-	scrolling = true
-	-- Hide cursor line
-	if opts.hide_cursor and move_cursor then
-		utils.hide_cursor()
-	end
-	-- Performance mode
-	local performance_mode = vim.b.neoscroll_performance_mode or vim.g.neoscroll_performance_mode
-	if performance_mode and move_cursor then
-		if vim.g.loaded_nvim_treesitter then
-			vim.cmd("TSBufDisable highlight")
-		end
-		vim.bo.syntax = "OFF"
-	end
-	-- Assign number of lines to scroll
-	target_line = lines
+local function before_scrolling(winid, lines, move_cursor, info)
+  if opts.pre_hook ~= nil then opts.pre_hook(info) end
+  local state = WindowState[winid]
+  -- Start scrolling
+  state.scrolling = true
+  -- Hide cursor line
+  if opts.hide_cursor and move_cursor and winid == 0 then utils.hide_cursor() end
+  -- Performance mode
+  local performance_mode = vim.b.neoscroll_performance_mode or
+                               vim.g.neoscroll_performance_mode
+  if performance_mode and move_cursor then
+    if vim.g.loaded_nvim_treesitter then vim.cmd("TSBufDisable highlight") end
+    vim.bo.syntax = "OFF"
+  end
+  -- Assign number of lines to scroll
+  state.target_line = lines
 end
 
 -- Scrolling destructor
-local function stop_scrolling(move_cursor, info)
-	if opts.hide_cursor == true and move_cursor then
-		utils.unhide_cursor()
-	end
-	--Performance mode
-	local performance_mode = vim.b.neoscroll_performance_mode or vim.g.neoscroll_performance_mode
-	if performance_mode and move_cursor then
-		vim.bo.syntax = "ON"
-		if vim.g.loaded_nvim_treesitter then
-			vim.cmd("TSBufEnable highlight")
-		end
-	end
-	if opts.post_hook ~= nil then
-		opts.post_hook(info)
-	end
+local function stop_scrolling(winid, move_cursor, info)
+  -- Note: winid may not exist anymore
+  if opts.hide_cursor == true and move_cursor and winid == 0 then
+    utils.unhide_cursor()
+  end
+  -- Performance mode
+  local performance_mode = vim.b.neoscroll_performance_mode or
+                               vim.g.neoscroll_performance_mode
+  if performance_mode and move_cursor then
+    vim.bo.syntax = "ON"
+    if vim.g.loaded_nvim_treesitter then vim.cmd("TSBufEnable highlight") end
+  end
+  if opts.post_hook ~= nil then opts.post_hook(info) end
+  local state = WindowState[winid]
+  -- window may be closed mid-scroll, and this would result in nil values
+  if state ~= nil then state.scroll_timer:stop() end
 
-	relative_line = 0
-	target_line = 0
-	scroll_timer:stop()
-	scrolling = false
-	continuous_scroll = false
+  WindowState[winid] = nil
 end
 
 local function compute_time_step(lines_to_scroll, lines, time, easing_function)
-	-- lines_to_scroll should always be positive
-	-- If there's less than one line to scroll time_step doesn't matter
-	if lines_to_scroll < 1 then
-		return 1000
-	end
-	local lines_range = math.abs(lines)
-	local ef = config.easing_functions[easing_function]
-	local time_step
-	-- If not yet in range return average time-step
-	if not ef then
-		time_step = math.floor(time / (lines_range - 1) + 0.5)
-	elseif lines_to_scroll >= lines_range then
-		time_step = math.floor(time * ef(1 / lines_range) + 0.5)
-	else
-		local x1 = (lines_range - lines_to_scroll) / lines_range
-		local x2 = (lines_range - lines_to_scroll + 1) / lines_range
-		time_step = math.floor(time * (ef(x2) - ef(x1)) + 0.5)
-	end
-	if time_step == 0 then
-		time_step = 1
-	end
-	return time_step
+  -- lines_to_scroll should always be positive
+  -- If there's less than one line to scroll time_step doesn't matter
+  if lines_to_scroll < 1 then return 1000 end
+  local lines_range = math.abs(lines)
+  local ef = config.easing_functions[easing_function]
+  local time_step
+  -- If not yet in range return average time-step
+  if not ef then
+    time_step = math.floor(time / (lines_range - 1) + 0.5)
+  elseif lines_to_scroll >= lines_range then
+    time_step = math.floor(time * ef(1 / lines_range) + 0.5)
+  else
+    local x1 = (lines_range - lines_to_scroll) / lines_range
+    local x2 = (lines_range - lines_to_scroll + 1) / lines_range
+    time_step = math.floor(time * (ef(x2) - ef(x1)) + 0.5)
+  end
+  if time_step == 0 then time_step = 1 end
+  return time_step
 end
 
 local neoscroll = {}
 
+local function callback_safe(fn, winid, move_cursor, info)
+  local function cb()
+    local ok, err = pcall(fn)
+    if not ok then
+      local ok2, err2 = pcall(stop_scrolling, winid, move_cursor, info)
+      if not ok2 then
+        local state = WindowState[winid]
+        if state ~= nil then WindowState[winid].scroll_timer:stop() end
+        -- something is horribly wrong if this happens
+        vim.api.nvim_echo({
+          {"neoscroll shutdown error:", "ErrorMsg"},
+          {tostring(err2), "ErrorMsg"}
+        }, true, {})
+      end
+      if type(err) ~= type("") or not err:lower():match("^.*invalid window id") then
+        vim.api.nvim_echo({
+          {"neoscroll scrolling error:", "ErrorMsg"},
+          {tostring(err), "ErrorMsg"}
+        }, true, {})
+      end
+    end
+  end
+
+  return cb
+end
+
+-- Callback function triggered by scroll_timer
+local function scroll_callback(winid, lines, move_cursor, time, ef, info)
+  local state = WindowState[winid]
+  local lines_to_scroll = state.target_line - state.relative_line
+
+  state.data = utils.get_data(winid)
+  local scroll_window, scroll_cursor
+  scroll_window, scroll_cursor =
+      who_scrolls(state, move_cursor, lines_to_scroll)
+
+  if not scroll_window and not scroll_cursor then
+    stop_scrolling(winid, move_cursor, info)
+    return
+  end
+
+  if math.abs(lines_to_scroll) > 2 and ef then
+    local next_lines_to_scroll = math.abs(lines_to_scroll) - 2
+    local next_time_step = compute_time_step(next_lines_to_scroll, lines, time,
+                                             ef)
+    -- sets the repeat of the next cycle
+    state.scroll_timer:set_repeat(next_time_step)
+  end
+  if math.abs(lines_to_scroll) == 0 then
+    stop_scrolling(winid, move_cursor, info)
+    return
+  end
+  scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, state)
+  if math.abs(lines_to_scroll) == 1 then
+    stop_scrolling(winid, move_cursor, info)
+    return
+  end
+end
+
 -- Scrolling function
+-- winid: id of the window to scroll (0 for current window)
 -- lines: number of lines to scroll or fraction of window to scroll
 -- move_cursor: scroll the window and the cursor simultaneously
 -- easing_function: name of the easing function to use for the scrolling animation
-function neoscroll.scroll(lines, move_cursor, time, easing_function, info)
-	-- If lines is a fraction of the window transform it to lines
-	if utils.is_float(lines) then
-		lines = utils.get_lines_from_win_fraction(lines)
-	end
-	if lines == 0 then
-		return
-	end
-	-- If still scrolling just modify the amount of lines to scroll
-	-- If the scroll is in the opposite direction and
-	-- lines_to_scroll is longer than lines stop smoothly
-	if scrolling then
-		local lines_to_scroll = relative_line - target_line
-		local opposite_direction = lines_to_scroll * lines > 0
-		local long_scroll = math.abs(lines_to_scroll) - math.abs(lines) > 0
-		if opposite_direction and long_scroll then
-			target_line = relative_line - lines
-		elseif continuous_scroll then
-			target_line = relative_line + 2 * lines
-		elseif math.abs(lines_to_scroll) > math.abs(5 * lines) then
-			continuous_scroll = true
-			relative_line = target_line - 2 * lines
-		else
-			target_line = target_line + lines
-		end
+function neoscroll.scroll_win(winid, lines, move_cursor, time, easing_function,
+    info)
+  local state = WindowState[winid]
+  state.winid = winid
+  -- If lines is a fraction of the window transform it to lines
+  if utils.is_float(lines) then
+    lines = utils.get_lines_from_win_fraction(winid, lines)
+  end
+  if lines == 0 then return end
 
-		return
-	end
-	-- Check if the window and the cursor are allowed to scroll in that direction
-	local data = utils.get_data()
-  local half_window = math.floor(data.window_height/2)
-  if utils.get_scrolloff() >= half_window then
-    cursor_win_line = half_window
-	elseif data.win_lines_above_cursor <= utils.get_scrolloff() then
-		cursor_win_line = utils.get_scrolloff() + 1
-	elseif data.win_lines_below_cursor <= utils.get_scrolloff() then
-		cursor_win_line = data.window_height - utils.get_scrolloff()
-	else
-		cursor_win_line = data.cursor_win_line
-	end
-	local scroll_window, scroll_cursor = who_scrolls(data, move_cursor, lines)
-	-- If neither the window nor the cursor are allowed to scroll finish early
-	if not scroll_window and not scroll_cursor then
-		return
-	end
-	-- Preparation before scrolling starts
-	before_scrolling(lines, move_cursor, info)
-	-- If easing function is not specified default to easing_function
-	local ef = easing_function and easing_function or opts.easing_function
-
-	local lines_to_scroll = math.abs(relative_line - target_line)
-	scroll_one_line(lines, scroll_window, scroll_cursor, data)
-	if lines_to_scroll == 1 then
-		stop_scrolling(move_cursor, info)
-	end
-	local time_step = compute_time_step(lines_to_scroll, lines, time, ef)
-	local next_time_step = compute_time_step(lines_to_scroll - 1, lines, time, ef)
-	local next_next_time_step = compute_time_step(lines_to_scroll - 2, lines, time, ef)
-	-- Scroll the first line
-
-	-- Callback function triggered by scroll_timer
-	local function scroll_callback()
-		lines_to_scroll = target_line - relative_line
-		data = utils.get_data()
-		scroll_window, scroll_cursor = who_scrolls(data, move_cursor, lines_to_scroll)
-		if not scroll_window and not scroll_cursor then
-			stop_scrolling(move_cursor, info)
-			return
-		end
-
-		if math.abs(lines_to_scroll) > 2 and ef then
-			local next_lines_to_scroll = math.abs(lines_to_scroll) - 2
-			next_time_step = compute_time_step(next_lines_to_scroll, lines, time, ef)
-			-- sets the repeat of the next cycle
-			scroll_timer:set_repeat(next_time_step)
-		end
-    if math.abs(lines_to_scroll) == 0 then
-      stop_scrolling(move_cursor, info)
-      return
+  -- If still scrolling just modify the amount of lines to scroll
+  -- If the scroll is in the opposite direction and
+  -- lines_to_scroll is longer than lines stop smoothly
+  if state.scrolling then
+    local lines_to_scroll = state.relative_line - state.target_line
+    local opposite_direction = lines_to_scroll * lines > 0
+    local long_scroll = math.abs(lines_to_scroll) - math.abs(lines) > 0
+    if opposite_direction and long_scroll then
+      state.target_line = state.relative_line - lines
+    elseif state.continuous_scroll then
+      state.target_line = state.relative_line + 2 * lines
+    elseif math.abs(lines_to_scroll) > math.abs(5 * lines) then
+      state.continuous_scroll = true
+      state.relative_line = state.target_line - 2 * lines
+    else
+      state.target_line = state.target_line + lines
     end
-		scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, data)
-		if math.abs(lines_to_scroll) == 1 then
-			stop_scrolling(move_cursor, info)
-			return
-		end
-	end
 
-	-- Start timer to scroll the rest of the lines
-	scroll_timer:start(time_step, next_time_step, vim.schedule_wrap(scroll_callback))
-	scroll_timer:set_repeat(next_next_time_step)
+    return
+  end
+
+  -- Check if the window and the cursor are allowed to scroll in that direction
+  state.data = utils.get_data(winid)
+  local half_window = math.floor(state.data.window_height / 2)
+  if state.scrolloff >= half_window then
+    state.cursor_win_line = half_window
+  elseif state.data.win_lines_above_cursor <= state.scrolloff then
+    state.cursor_win_line = state.scrolloff + 1
+  elseif state.data.win_lines_below_cursor <= state.scrolloff then
+    state.cursor_win_line = state.data.window_height - state.scrolloff
+  else
+    state.cursor_win_line = state.data.cursor_win_line
+  end
+
+  local scroll_window, scroll_cursor = who_scrolls(state, move_cursor, lines)
+  -- If neither the window nor the cursor are allowed to scroll finish early
+  if not scroll_window and not scroll_cursor then return end
+  -- Preparation before scrolling starts
+  before_scrolling(winid, lines, move_cursor, info)
+  -- If easing function is not specified default to easing_function
+  local ef = easing_function and easing_function or opts.easing_function
+
+  local lines_to_scroll = math.abs(state.relative_line - state.target_line)
+  scroll_one_line(lines, scroll_window, scroll_cursor, state)
+  if lines_to_scroll == 1 then stop_scrolling(winid, move_cursor, info) end
+  local time_step = compute_time_step(lines_to_scroll, lines, time, ef)
+  local next_time_step = compute_time_step(lines_to_scroll - 1, lines, time, ef)
+  local next_next_time_step = compute_time_step(lines_to_scroll - 2, lines,
+                                                time, ef)
+  -- Scroll the first line
+
+  -- Start timer to scroll the rest of the lines
+  state.scroll_timer:start(time_step, next_time_step,
+                           vim.schedule_wrap(
+      callback_safe(function()
+        scroll_callback(winid, lines, move_cursor, time, ef, info)
+      end, winid, move_cursor, info)))
+  state.scroll_timer:set_repeat(next_next_time_step)
 end
+
+function neoscroll.scroll(...) return neoscroll.scroll_win(0, ...) end
 
 -- Wrapper for zt
+function neoscroll.zt_win(winid, half_screen_time, easing, info)
+  local window_height = vim.api.nvim_win_get_height(winid)
+  -- TODO figure out why this -2 is needed (also needed in master)
+  --      one guess: because scrolloff is -1
+  local win_lines_above_cursor = utils.getwinline(winid) - 1
+  -- Temporary fix for garbage values in local scrolloff when not set
+  local lines = win_lines_above_cursor -
+                    utils.get_scrolloff(winid, opts.use_local_scrolloff)
+  if lines == 0 then return end
+  local corrected_time = math.floor(half_screen_time *
+                                        (math.abs(lines) / (window_height / 2)) +
+                                        0.5)
+  neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
+end
+
 function neoscroll.zt(half_screen_time, easing, info)
-	local window_height = vim.api.nvim_win_get_height(0)
-	local win_lines_above_cursor = vim.fn.winline() - 1
-	-- Temporary fix for garbage values in local scrolloff when not set
-	local lines = win_lines_above_cursor - utils.get_scrolloff()
-	if lines == 0 then
-		return
-	end
-	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
-	neoscroll.scroll(lines, false, corrected_time, easing, info)
+  return neoscroll.zt_win(0, half_screen_time, easing, info)
 end
+
 -- Wrapper for zz
-function neoscroll.zz(half_screen_time, easing, info)
-	local window_height = vim.api.nvim_win_get_height(0)
-	local lines = vim.fn.winline() - math.ceil(window_height / 2)
-	if lines == 0 then
-		return
-	end
-	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
-	neoscroll.scroll(lines, false, corrected_time, easing, info)
+function neoscroll.zz_win(winid, half_screen_time, easing, info)
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local lines = utils.getwinline(winid) - math.floor(window_height / 2 + 1)
+  if lines == 0 then return end
+  local corrected_time = math.floor(half_screen_time *
+                                        (math.abs(lines) / (window_height / 2)) +
+                                        0.5)
+  neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
 end
+
+function neoscroll.zz(half_screen_time, easing, info)
+  return neoscroll.zz_win(0, half_screen_time, easing, info)
+end
+
 -- Wrapper for zb
+function neoscroll.zb_win(winid, half_screen_time, easing, info)
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local lines_below_cursor = window_height - utils.getwinline(winid)
+  -- Temporary fix for garbage values in local scrolloff when not set
+  local lines = -lines_below_cursor +
+                    utils.get_scrolloff(winid, opts.use_local_scrolloff)
+  if lines == 0 then return end
+  local corrected_time = math.floor(half_screen_time *
+                                        (math.abs(lines) / (window_height / 2)) +
+                                        0.5)
+  neoscroll.scroll(lines, false, corrected_time, easing, info)
+end
+
 function neoscroll.zb(half_screen_time, easing, info)
-	local window_height = vim.api.nvim_win_get_height(0)
-	local lines_below_cursor = window_height - vim.fn.winline()
-	-- Temporary fix for garbage values in local scrolloff when not set
-	local lines = -lines_below_cursor + utils.get_scrolloff()
-	if lines == 0 then
-		return
-	end
-	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
-	neoscroll.scroll(lines, false, corrected_time, easing, info)
+  return neoscroll.zb_win(0, half_screen_time, easing, info)
+end
+
+function neoscroll.G_win(winid, half_screen_time, easing, info)
+  local lines = utils.get_lines_below(winid, vim.fn.line("w$", winid))
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local corrected_time = math.floor(half_screen_time *
+                                        (math.abs(lines) / (window_height / 2)) +
+                                        0.5)
+  neoscroll.scroll_win(winid, lines, true, corrected_time, easing, info)
 end
 
 function neoscroll.G(half_screen_time, easing, info)
-	local lines = utils.get_lines_below(vim.fn.line("w$"))
-	local window_height = vim.api.nvim_win_get_height(0)
-	local cursor_win_line = vim.fn.winline()
-	local win_lines_below_cursor = window_height - cursor_win_line
-	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
-	neoscroll.scroll(lines, true, corrected_time, easing, { G = true })
+  return neoscroll.G_win(0, half_screen_time, easing, info)
+end
+
+function neoscroll.gg_win(winid, half_screen_time, easing, info)
+  local lines = utils.get_lines_above(winid, vim.fn.line("w0", winid))
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local cursor_win_line = utils.getwinline(winid)
+  lines = -lines - cursor_win_line
+  local corrected_time = math.floor(half_screen_time *
+                                        (math.abs(lines) / (window_height / 2)) +
+                                        0.5)
+  neoscroll.scroll_win(winid, lines, true, corrected_time, easing, info)
 end
 
 function neoscroll.gg(half_screen_time, easing, info)
-	local lines = utils.get_lines_above(vim.fn.line("w0"))
-	local window_height = vim.api.nvim_win_get_height(0)
-	local cursor_win_line = vim.fn.winline()
-	lines = -lines - cursor_win_line
-	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
-	neoscroll.scroll(lines, true, corrected_time, easing, info)
+  return neoscroll.gg_win(0, half_screen_time, easing, info)
 end
 
 function neoscroll.setup(custom_opts)
-	config.set_options(custom_opts)
-	opts = require("neoscroll.config").options
-	require("neoscroll.config").set_mappings()
-	vim.cmd("command! NeoscrollEnablePM let b:neoscroll_performance_mode = v:true")
-	vim.cmd("command! NeoscrollDisablePM let b:neoscroll_performance_mode = v:false")
-	vim.cmd("command! NeoscrollEnableBufferPM let b:neoscroll_performance_mode = v:true")
-	vim.cmd("command! NeoscrollDisableBufferPM let b:neoscroll_performance_mode = v:false")
-	vim.cmd("command! NeoscrollEnableGlobalPM let g:neoscroll_performance_mode = v:true")
-	vim.cmd("command! NeoscrollDisablGlobalePM let g:neoscroll_performance_mode = v:false")
-	if opts.performance_mode then
-		vim.g.neoscroll_performance_mode = true
-	end
+  config.set_options(custom_opts)
+  opts = require("neoscroll.config").options
+  require("neoscroll.config").set_mappings()
+  vim.cmd("command! NeoscrollEnablePM let b:neoscroll_performance_mode = v:true")
+  vim.cmd("command! NeoscrollDisablePM let b:neoscroll_performance_mode = v:false")
+  vim.cmd("command! NeoscrollEnableBufferPM let b:neoscroll_performance_mode = v:true")
+  vim.cmd("command! NeoscrollDisableBufferPM let b:neoscroll_performance_mode = v:false")
+  vim.cmd("command! NeoscrollEnableGlobalPM let g:neoscroll_performance_mode = v:true")
+  vim.cmd("command! NeoscrollDisablGlobalePM let g:neoscroll_performance_mode = v:false")
+  if opts.performance_mode then vim.g.neoscroll_performance_mode = true end
 end
 
 return neoscroll

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -451,7 +451,7 @@ function neoscroll.zb_win(winid, half_screen_time, easing, info)
 	local corrected_time = math.floor(
 		half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5
 	)
-	neoscroll.scroll(lines, false, corrected_time, easing, info)
+	neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
 end
 
 function neoscroll.zb(half_screen_time, easing, info)
@@ -462,7 +462,7 @@ function neoscroll.G_win(winid, half_screen_time, easing, info)
 	local lines = utils.get_lines_below(winid, utils.getline(winid, "w$"))
 	local window_height = vim.api.nvim_win_get_height(winid)
 	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
-	neoscroll.scroll(lines, true, corrected_time, easing, { G = true })
+	neoscroll.scroll_win(winid, lines, true, corrected_time, easing, { G = true })
 end
 
 function neoscroll.G(half_screen_time, easing, info)

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -257,7 +257,7 @@ local function callback_safe(fn, winid, move_cursor, info)
 		if not ok then
 			local ok2, err2 = pcall(stop_scrolling, winid, move_cursor, info)
 			if not ok2 then
-				local state = WindowState[winid]
+				local state = rawget(WindowState, winid)
 				if state ~= nil then
 					WindowState[winid].scroll_timer:stop()
 				end

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -406,8 +406,6 @@ end
 -- Wrapper for zt
 function neoscroll.zt_win(winid, half_screen_time, easing, info)
 	local window_height = vim.api.nvim_win_get_height(winid)
-	-- TODO figure out why this -2 is needed (also needed in master)
-	--      one guess: because scrolloff is -1
 	local win_lines_above_cursor = utils.getwinline(winid) - 1
 	-- Temporary fix for garbage values in local scrolloff when not set
 	local lines = win_lines_above_cursor - utils.get_scrolloff(winid, opts.use_local_scrolloff)

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -215,7 +215,7 @@ local function stop_scrolling(winid, move_cursor, info)
 	if opts.post_hook ~= nil then
 		opts.post_hook(info)
 	end
-	local state = WindowState[winid]
+	local state = rawget(WindowState, winid)
 	-- window may be closed mid-scroll, and this would result in nil values
 	if state ~= nil then
 		state.scroll_timer:stop()

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -4,313 +4,307 @@ local opts
 
 -- Highlight group to hide the cursor
 vim.api.nvim_exec(
-	[[
+  [[
 augroup custom_highlight
 autocmd!
 autocmd ColorScheme * highlight NeoscrollHiddenCursor gui=reverse blend=100
 augroup END
 ]],
-	true
+  true
 )
 vim.cmd("highlight NeoscrollHiddenCursor gui=reverse blend=100")
 
 local WindowState = {
-	__index = function(state_table, winid)
-		assert(type(winid) == type(0) and winid >= 0,
-			"Expected a non-negative window id, got " .. tostring(winid)
-		)
-		local state = {
-			winid = winid,
-			scroll_timer = vim.loop.new_timer(),
-			target_line = 0,
-			relative_line = 0,
-			cursor_win_line = nil, -- set inside scroll()
-			scrolling = false,
-			continuous_scroll = false,
-			data = nil, -- set inside scroll()
-			scrolloff = utils.get_scrolloff(winid, opts.use_local_scrolloff)
-		}
-		state_table[winid] = state
-		return state
-	end
+  __index = function(state_table, winid)
+    assert(
+      type(winid) == type(0) and winid >= 0,
+      "Expected a non-negative window id, got " .. tostring(winid)
+    )
+    local state = {
+      winid = winid,
+      scroll_timer = vim.loop.new_timer(),
+      target_line = 0,
+      relative_line = 0,
+      cursor_win_line = nil, -- set inside scroll()
+      scrolling = false,
+      continuous_scroll = false,
+      data = nil, -- set inside scroll()
+      scrolloff = utils.get_scrolloff(winid, opts.use_local_scrolloff),
+    }
+    state_table[winid] = state
+    return state
+  end,
 }
 setmetatable(WindowState, WindowState)
 
 -- excecute commands to scroll screen [and cursor] up/down one line
 -- The bang (!) `normal!` in normal ignores mappings
 local function scroll_up(state, scroll_window, scroll_cursor, n_repeat)
-	local n = n_repeat == nil and 1 or n_repeat
-	local cursor_scroll_input = scroll_cursor and tostring(n) .. "gk" or ""
-	local window_scroll_input = scroll_window and tostring(n) .. [[<C-y>]] or ""
-	local data = state.data
-	local scroll_input
-	-- if scrolloff or window edge are going to move the cursor for you then only
-	-- scroll the window
-	if (
-			(
-					data.last_line_visible
-							and data.win_lines_below_cursor == data.lines_below_cursor
-							and data.lines_below_cursor <= state.scrolloff
-					) or data.win_lines_below_cursor == state.scrolloff
-			) and scroll_window
-	then
-		scroll_input = window_scroll_input
-	else
-		scroll_input = window_scroll_input .. cursor_scroll_input
-	end
-	utils.with_winid(state.winid, function()
-		local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true, true)
-		vim.api.nvim_cmd(
-			{ cmd = "normal", bang = true, args = { escaped } },
-			{ output = false }
-		)
-	end)
+  local n = n_repeat == nil and 1 or n_repeat
+  local cursor_scroll_input = scroll_cursor and tostring(n) .. "gk" or ""
+  local window_scroll_input = scroll_window and tostring(n) .. [[<C-y>]] or ""
+  local data = state.data
+  local scroll_input
+  -- if scrolloff or window edge are going to move the cursor for you then only
+  -- scroll the window
+  if
+    (
+      (
+        data.last_line_visible
+        and data.win_lines_below_cursor == data.lines_below_cursor
+        and data.lines_below_cursor <= state.scrolloff
+      ) or data.win_lines_below_cursor == state.scrolloff
+    ) and scroll_window
+  then
+    scroll_input = window_scroll_input
+  else
+    scroll_input = window_scroll_input .. cursor_scroll_input
+  end
+  utils.with_winid(state.winid, function()
+    local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true, true)
+    vim.api.nvim_cmd({ cmd = "normal", bang = true, args = { escaped } }, { output = false })
+  end)
 end
 
 local function scroll_down(state, scroll_window, scroll_cursor, n_repeat)
-	local n = n_repeat == nil and 1 or n_repeat
-	local cursor_scroll_input = scroll_cursor and tostring(n) .. "gj" or ""
-	local window_scroll_input = scroll_window and tostring(n) .. [[<C-e>]] or ""
-	local data = state.data
-	local scroll_input
-	-- if scrolloff or window edge are going to move the cursor for you then only
-	-- scroll the window
-	if (
-			(data.first_line_visible and data.win_lines_above_cursor <= state.scrolloff)
-					or data.win_lines_above_cursor <= state.scrolloff
-			) and scroll_window
-	then
-		scroll_input = window_scroll_input
-	else
-		scroll_input = window_scroll_input .. cursor_scroll_input
-	end
-	utils.with_winid(state.winid, function()
-		local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true, true)
-		vim.api.nvim_cmd(
-			{ cmd = "normal", bang = true, args = { escaped } },
-			{ output = false }
-		)
-	end)
+  local n = n_repeat == nil and 1 or n_repeat
+  local cursor_scroll_input = scroll_cursor and tostring(n) .. "gj" or ""
+  local window_scroll_input = scroll_window and tostring(n) .. [[<C-e>]] or ""
+  local data = state.data
+  local scroll_input
+  -- if scrolloff or window edge are going to move the cursor for you then only
+  -- scroll the window
+  if
+    (
+      (data.first_line_visible and data.win_lines_above_cursor <= state.scrolloff)
+      or data.win_lines_above_cursor <= state.scrolloff
+    ) and scroll_window
+  then
+    scroll_input = window_scroll_input
+  else
+    scroll_input = window_scroll_input .. cursor_scroll_input
+  end
+  utils.with_winid(state.winid, function()
+    local escaped = vim.api.nvim_replace_termcodes(scroll_input, true, true, true)
+    vim.api.nvim_cmd({ cmd = "normal", bang = true, args = { escaped } }, { output = false })
+  end)
 end
 
 -- Window rules for when to stop scrolling
 local function window_reached_limit(state, move_cursor, direction)
-	local data = state.data
-	if data.last_line_visible and direction > 0 then
-		if move_cursor then
-			if opts.stop_eof and data.lines_below_cursor == data.win_lines_below_cursor then
-				return true
-			elseif opts.respect_scrolloff and data.lines_below_cursor <= state.scrolloff then
-				return true
-			else
-				return data.lines_below_cursor == 0
-			end
-		else
-			return data.lines_below_cursor == 0 and data.win_lines_above_cursor == 0
-		end
-	elseif data.first_line_visible and direction < 0 then
-		return true
-	else
-		return false
-	end
+  local data = state.data
+  if data.last_line_visible and direction > 0 then
+    if move_cursor then
+      if opts.stop_eof and data.lines_below_cursor == data.win_lines_below_cursor then
+        return true
+      elseif opts.respect_scrolloff and data.lines_below_cursor <= state.scrolloff then
+        return true
+      else
+        return data.lines_below_cursor == 0
+      end
+    else
+      return data.lines_below_cursor == 0 and data.win_lines_above_cursor == 0
+    end
+  elseif data.first_line_visible and direction < 0 then
+    return true
+  else
+    return false
+  end
 end
 
 -- Cursor rules for when to stop scrolling
 local function cursor_reached_limit(state)
-	local data = state.data
-	if data.first_line_visible then
-		if opts.respect_scrolloff and data.win_lines_above_cursor <= state.scrolloff then
-			return true
-		end
-		return data.win_lines_above_cursor == 0
-	elseif data.last_line_visible then
-		if opts.respect_scrolloff and data.lines_below_cursor <= state.scrolloff then
-			return true
-		end
-		return data.lines_below_cursor == 0
-	end
+  local data = state.data
+  if data.first_line_visible then
+    if opts.respect_scrolloff and data.win_lines_above_cursor <= state.scrolloff then
+      return true
+    end
+    return data.win_lines_above_cursor == 0
+  elseif data.last_line_visible then
+    if opts.respect_scrolloff and data.lines_below_cursor <= state.scrolloff then
+      return true
+    end
+    return data.lines_below_cursor == 0
+  end
 end
 
 -- Check if the window and the cursor can be scrolled further
 local function who_scrolls(state, move_cursor, direction)
-	local data = state.data
-	local scroll_window, scroll_cursor
-	local half_window = math.floor(data.window_height / 2)
-	scroll_window = not window_reached_limit(state, move_cursor, direction)
-	if not move_cursor then
-		scroll_cursor = false
-	elseif scroll_window then
-		if state.scrolloff < half_window then
-			scroll_cursor = true
-		else
-			scroll_cursor = false
-		end
-	elseif opts.cursor_scrolls_alone then
-		scroll_cursor = not cursor_reached_limit(state)
-	else
-		scroll_cursor = false
-	end
-	return scroll_window, scroll_cursor
+  local data = state.data
+  local scroll_window, scroll_cursor
+  local half_window = math.floor(data.window_height / 2)
+  scroll_window = not window_reached_limit(state, move_cursor, direction)
+  if not move_cursor then
+    scroll_cursor = false
+  elseif scroll_window then
+    if state.scrolloff < half_window then
+      scroll_cursor = true
+    else
+      scroll_cursor = false
+    end
+  elseif opts.cursor_scrolls_alone then
+    scroll_cursor = not cursor_reached_limit(state)
+  else
+    scroll_cursor = false
+  end
+  return scroll_window, scroll_cursor
 end
 
 -- Scroll one line in the given direction
 local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, state)
-	if lines_to_scroll > 0 then
-		state.relative_line = state.relative_line + 1
-		scroll_down(state, scroll_window, scroll_cursor)
-		-- Correct for wrapped lines
-		local lines_behind = state.cursor_win_line - utils.getwinline(state.winid)
-		if scroll_cursor and scroll_window and lines_behind > 0 then
-			scroll_down(state, false, scroll_cursor, lines_behind)
-		end
-	else
-		state.relative_line = state.relative_line - 1
-		scroll_up(state, scroll_window, scroll_cursor)
-		-- Correct for wrapped lines
-		local lines_behind = utils.getwinline(state.winid) - state.cursor_win_line
-		if scroll_cursor and scroll_window and lines_behind > 0 then
-			scroll_up(state, false, scroll_cursor, lines_behind)
-		end
-	end
+  if lines_to_scroll > 0 then
+    state.relative_line = state.relative_line + 1
+    scroll_down(state, scroll_window, scroll_cursor)
+    -- Correct for wrapped lines
+    local lines_behind = state.cursor_win_line - utils.getwinline(state.winid)
+    if scroll_cursor and scroll_window and lines_behind > 0 then
+      scroll_down(state, false, scroll_cursor, lines_behind)
+    end
+  else
+    state.relative_line = state.relative_line - 1
+    scroll_up(state, scroll_window, scroll_cursor)
+    -- Correct for wrapped lines
+    local lines_behind = utils.getwinline(state.winid) - state.cursor_win_line
+    if scroll_cursor and scroll_window and lines_behind > 0 then
+      scroll_up(state, false, scroll_cursor, lines_behind)
+    end
+  end
 end
 
 -- Scrolling constructor
 local function before_scrolling(winid, lines, move_cursor, info)
-	if opts.pre_hook ~= nil then
-		opts.pre_hook(info)
-	end
-	local state = WindowState[winid]
-	-- Start scrolling
-	state.scrolling = true
-	-- Hide cursor line
-	if opts.hide_cursor and move_cursor and winid == 0 then
-		utils.hide_cursor()
-	end
-	-- Performance mode
-	local performance_mode = vim.b.neoscroll_performance_mode or vim.g.neoscroll_performance_mode
-	if performance_mode and move_cursor then
-		if vim.g.loaded_nvim_treesitter then
-			vim.cmd("TSBufDisable highlight")
-		end
-		vim.bo.syntax = "OFF"
-	end
-	-- Assign number of lines to scroll
-	state.target_line = lines
+  if opts.pre_hook ~= nil then
+    opts.pre_hook(info)
+  end
+  local state = WindowState[winid]
+  -- Start scrolling
+  state.scrolling = true
+  -- Hide cursor line
+  if opts.hide_cursor and move_cursor and winid == 0 then
+    utils.hide_cursor()
+  end
+  -- Performance mode
+  local performance_mode = vim.b.neoscroll_performance_mode or vim.g.neoscroll_performance_mode
+  if performance_mode and move_cursor then
+    if vim.g.loaded_nvim_treesitter then
+      vim.cmd("TSBufDisable highlight")
+    end
+    vim.bo.syntax = "OFF"
+  end
+  -- Assign number of lines to scroll
+  state.target_line = lines
 end
 
 -- Scrolling destructor
 local function stop_scrolling(winid, move_cursor, info)
-	-- Note: winid may not exist anymore
-	if opts.hide_cursor == true and move_cursor and winid == 0 then
-		utils.unhide_cursor()
-	end
-	--Performance mode
-	local performance_mode = vim.b.neoscroll_performance_mode or vim.g.neoscroll_performance_mode
-	if performance_mode and move_cursor then
-		vim.bo.syntax = "ON"
-		if vim.g.loaded_nvim_treesitter then
-			vim.cmd("TSBufEnable highlight")
-		end
-	end
-	if opts.post_hook ~= nil then
-		opts.post_hook(info)
-	end
-	local state = rawget(WindowState, winid)
-	-- window may be closed mid-scroll, and this would result in nil values
-	if state ~= nil then
-		state.scroll_timer:stop()
-	end
+  -- Note: winid may not exist anymore
+  if opts.hide_cursor == true and move_cursor and winid == 0 then
+    utils.unhide_cursor()
+  end
+  --Performance mode
+  local performance_mode = vim.b.neoscroll_performance_mode or vim.g.neoscroll_performance_mode
+  if performance_mode and move_cursor then
+    vim.bo.syntax = "ON"
+    if vim.g.loaded_nvim_treesitter then
+      vim.cmd("TSBufEnable highlight")
+    end
+  end
+  if opts.post_hook ~= nil then
+    opts.post_hook(info)
+  end
+  local state = rawget(WindowState, winid)
+  -- window may be closed mid-scroll, and this would result in nil values
+  if state ~= nil then
+    state.scroll_timer:stop()
+  end
 
-	WindowState[winid] = nil
+  WindowState[winid] = nil
 end
 
 local function compute_time_step(lines_to_scroll, lines, time, easing_function)
-	-- lines_to_scroll should always be positive
-	-- If there's less than one line to scroll time_step doesn't matter
-	if lines_to_scroll < 1 then
-		return 1000
-	end
-	local lines_range = math.abs(lines)
-	local ef = config.easing_functions[easing_function]
-	local time_step
-	-- If not yet in range return average time-step
-	if not ef then
-		time_step = math.floor(time / (lines_range - 1) + 0.5)
-	elseif lines_to_scroll >= lines_range then
-		time_step = math.floor(time * ef(1 / lines_range) + 0.5)
-	else
-		local x1 = (lines_range - lines_to_scroll) / lines_range
-		local x2 = (lines_range - lines_to_scroll + 1) / lines_range
-		time_step = math.floor(time * (ef(x2) - ef(x1)) + 0.5)
-	end
-	if time_step == 0 then
-		time_step = 1
-	end
-	return time_step
+  -- lines_to_scroll should always be positive
+  -- If there's less than one line to scroll time_step doesn't matter
+  if lines_to_scroll < 1 then
+    return 1000
+  end
+  local lines_range = math.abs(lines)
+  local ef = config.easing_functions[easing_function]
+  local time_step
+  -- If not yet in range return average time-step
+  if not ef then
+    time_step = math.floor(time / (lines_range - 1) + 0.5)
+  elseif lines_to_scroll >= lines_range then
+    time_step = math.floor(time * ef(1 / lines_range) + 0.5)
+  else
+    local x1 = (lines_range - lines_to_scroll) / lines_range
+    local x2 = (lines_range - lines_to_scroll + 1) / lines_range
+    time_step = math.floor(time * (ef(x2) - ef(x1)) + 0.5)
+  end
+  if time_step == 0 then
+    time_step = 1
+  end
+  return time_step
 end
 
 local neoscroll = {}
 
 local function callback_safe(fn, winid, move_cursor, info)
-	local function cb()
-		local ok, err = pcall(fn)
-		if not ok then
-			local ok2, err2 = pcall(stop_scrolling, winid, move_cursor, info)
-			if not ok2 then
-				local state = rawget(WindowState, winid)
-				if state ~= nil then
-					WindowState[winid].scroll_timer:stop()
-				end
-				-- something is horribly wrong if this happens
-				vim.api.nvim_echo({
-					{ "neoscroll shutdown error:", "ErrorMsg" },
-					{ tostring(err2), "ErrorMsg" },
-				}, true, {})
-			end
-			if type(err) ~= type("")
-					or not err:lower():match("^.*invalid window id") then
-				vim.api.nvim_echo({
-					{ "neoscroll scrolling error:", "ErrorMsg" },
-					{ tostring(err), "ErrorMsg" }
-				}, true, {})
-			end
-		end
-	end
+  local function cb()
+    local ok, err = pcall(fn)
+    if not ok then
+      local ok2, err2 = pcall(stop_scrolling, winid, move_cursor, info)
+      if not ok2 then
+        local state = rawget(WindowState, winid)
+        if state ~= nil then
+          WindowState[winid].scroll_timer:stop()
+        end
+        -- something is horribly wrong if this happens
+        vim.api.nvim_echo({
+          { "neoscroll shutdown error:", "ErrorMsg" },
+          { tostring(err2), "ErrorMsg" },
+        }, true, {})
+      end
+      if type(err) ~= type("") or not err:lower():match("^.*invalid window id") then
+        vim.api.nvim_echo({
+          { "neoscroll scrolling error:", "ErrorMsg" },
+          { tostring(err), "ErrorMsg" },
+        }, true, {})
+      end
+    end
+  end
 
-	return cb
+  return cb
 end
 
 -- Callback function triggered by scroll_timer
 local function scroll_callback(winid, lines, move_cursor, time, ef, info)
-	local state = WindowState[winid]
-	local lines_to_scroll = state.target_line - state.relative_line
+  local state = WindowState[winid]
+  local lines_to_scroll = state.target_line - state.relative_line
 
-	state.data = utils.get_data(winid)
-	local scroll_window, scroll_cursor
-	scroll_window, scroll_cursor = who_scrolls(
-		state, move_cursor, lines_to_scroll
-	)
+  state.data = utils.get_data(winid)
+  local scroll_window, scroll_cursor
+  scroll_window, scroll_cursor = who_scrolls(state, move_cursor, lines_to_scroll)
 
-	if not scroll_window and not scroll_cursor then
-		stop_scrolling(winid, move_cursor, info)
-		return
-	end
+  if not scroll_window and not scroll_cursor then
+    stop_scrolling(winid, move_cursor, info)
+    return
+  end
 
-	if math.abs(lines_to_scroll) > 2 and ef then
-		local next_lines_to_scroll = math.abs(lines_to_scroll) - 2
-		local next_time_step = compute_time_step(next_lines_to_scroll, lines, time, ef)
-		-- sets the repeat of the next cycle
-		state.scroll_timer:set_repeat(next_time_step)
-	end
-	if math.abs(lines_to_scroll) == 0 then
-		stop_scrolling(winid, move_cursor, info)
-		return
-	end
-	scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, state)
-	if math.abs(lines_to_scroll) == 1 then
-		stop_scrolling(winid, move_cursor, info)
-		return
-	end
+  if math.abs(lines_to_scroll) > 2 and ef then
+    local next_lines_to_scroll = math.abs(lines_to_scroll) - 2
+    local next_time_step = compute_time_step(next_lines_to_scroll, lines, time, ef)
+    -- sets the repeat of the next cycle
+    state.scroll_timer:set_repeat(next_time_step)
+  end
+  if math.abs(lines_to_scroll) == 0 then
+    stop_scrolling(winid, move_cursor, info)
+    return
+  end
+  scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, state)
+  if math.abs(lines_to_scroll) == 1 then
+    stop_scrolling(winid, move_cursor, info)
+    return
+  end
 end
 
 -- Scrolling function
@@ -319,182 +313,176 @@ end
 -- move_cursor: scroll the window and the cursor simultaneously
 -- easing_function: name of the easing function to use for the scrolling animation
 function neoscroll.scroll_win(winid, lines, move_cursor, time, easing_function, info)
-	local state = WindowState[winid]
-	state.winid = winid
-	-- If lines is a fraction of the window transform it to lines
-	if utils.is_float(lines) then
-		lines = utils.get_lines_from_win_fraction(winid, lines)
-	end
-	if lines == 0 then
-		return
-	end
+  local state = WindowState[winid]
+  state.winid = winid
+  -- If lines is a fraction of the window transform it to lines
+  if utils.is_float(lines) then
+    lines = utils.get_lines_from_win_fraction(winid, lines)
+  end
+  if lines == 0 then
+    return
+  end
 
-	-- If still scrolling just modify the amount of lines to scroll
-	-- If the scroll is in the opposite direction and
-	-- lines_to_scroll is longer than lines stop smoothly
-	if state.scrolling then
-		local lines_to_scroll = state.relative_line - state.target_line
-		local opposite_direction = lines_to_scroll * lines > 0
-		local long_scroll = math.abs(lines_to_scroll) - math.abs(lines) > 0
-		if opposite_direction and long_scroll then
-			state.target_line = state.relative_line - lines
-		elseif state.continuous_scroll then
-			state.target_line = state.relative_line + 2 * lines
-		elseif math.abs(lines_to_scroll) > math.abs(5 * lines) then
-			state.continuous_scroll = true
-			state.relative_line = state.target_line - 2 * lines
-		else
-			state.target_line = state.target_line + lines
-		end
+  -- If still scrolling just modify the amount of lines to scroll
+  -- If the scroll is in the opposite direction and
+  -- lines_to_scroll is longer than lines stop smoothly
+  if state.scrolling then
+    local lines_to_scroll = state.relative_line - state.target_line
+    local opposite_direction = lines_to_scroll * lines > 0
+    local long_scroll = math.abs(lines_to_scroll) - math.abs(lines) > 0
+    if opposite_direction and long_scroll then
+      state.target_line = state.relative_line - lines
+    elseif state.continuous_scroll then
+      state.target_line = state.relative_line + 2 * lines
+    elseif math.abs(lines_to_scroll) > math.abs(5 * lines) then
+      state.continuous_scroll = true
+      state.relative_line = state.target_line - 2 * lines
+    else
+      state.target_line = state.target_line + lines
+    end
 
-		return
-	end
+    return
+  end
 
-	-- Check if the window and the cursor are allowed to scroll in that direction
-	state.data = utils.get_data(winid)
-	local half_window = math.floor(state.data.window_height / 2)
-	if state.scrolloff >= half_window then
-		state.cursor_win_line = half_window
-	elseif state.data.win_lines_above_cursor <= state.scrolloff then
-		state.cursor_win_line = state.scrolloff + 1
-	elseif state.data.win_lines_below_cursor <= state.scrolloff then
-		state.cursor_win_line = state.data.window_height - state.scrolloff
-	else
-		state.cursor_win_line = state.data.cursor_win_line
-	end
+  -- Check if the window and the cursor are allowed to scroll in that direction
+  state.data = utils.get_data(winid)
+  local half_window = math.floor(state.data.window_height / 2)
+  if state.scrolloff >= half_window then
+    state.cursor_win_line = half_window
+  elseif state.data.win_lines_above_cursor <= state.scrolloff then
+    state.cursor_win_line = state.scrolloff + 1
+  elseif state.data.win_lines_below_cursor <= state.scrolloff then
+    state.cursor_win_line = state.data.window_height - state.scrolloff
+  else
+    state.cursor_win_line = state.data.cursor_win_line
+  end
 
-	local scroll_window, scroll_cursor = who_scrolls(state, move_cursor, lines)
-	-- If neither the window nor the cursor are allowed to scroll finish early
-	if not scroll_window and not scroll_cursor then
-		return
-	end
-	-- Preparation before scrolling starts
-	before_scrolling(winid, lines, move_cursor, info)
-	-- If easing function is not specified default to easing_function
-	local ef = easing_function and easing_function or opts.easing_function
+  local scroll_window, scroll_cursor = who_scrolls(state, move_cursor, lines)
+  -- If neither the window nor the cursor are allowed to scroll finish early
+  if not scroll_window and not scroll_cursor then
+    return
+  end
+  -- Preparation before scrolling starts
+  before_scrolling(winid, lines, move_cursor, info)
+  -- If easing function is not specified default to easing_function
+  local ef = easing_function and easing_function or opts.easing_function
 
-	local lines_to_scroll = math.abs(state.relative_line - state.target_line)
-	scroll_one_line(lines, scroll_window, scroll_cursor, state)
-	if lines_to_scroll == 1 then
-		stop_scrolling(winid, move_cursor, info)
-	end
-	local time_step = compute_time_step(lines_to_scroll, lines, time, ef)
-	local next_time_step = compute_time_step(lines_to_scroll - 1, lines, time, ef)
-	local next_next_time_step = compute_time_step(lines_to_scroll - 2, lines, time, ef)
-	-- Scroll the first line
+  local lines_to_scroll = math.abs(state.relative_line - state.target_line)
+  scroll_one_line(lines, scroll_window, scroll_cursor, state)
+  if lines_to_scroll == 1 then
+    stop_scrolling(winid, move_cursor, info)
+  end
+  local time_step = compute_time_step(lines_to_scroll, lines, time, ef)
+  local next_time_step = compute_time_step(lines_to_scroll - 1, lines, time, ef)
+  local next_next_time_step = compute_time_step(lines_to_scroll - 2, lines, time, ef)
+  -- Scroll the first line
 
-	-- Start timer to scroll the rest of the lines
-	state.scroll_timer:start(
-		time_step, next_time_step,
-		vim.schedule_wrap(
-			callback_safe(function()
-				scroll_callback(winid, lines, move_cursor, time, ef, info)
-			end,
-				winid,
-				move_cursor,
-				info
-			)
-		)
-	)
-	state.scroll_timer:set_repeat(next_next_time_step)
+  -- Start timer to scroll the rest of the lines
+  state.scroll_timer:start(
+    time_step,
+    next_time_step,
+    vim.schedule_wrap(callback_safe(function()
+      scroll_callback(winid, lines, move_cursor, time, ef, info)
+    end, winid, move_cursor, info))
+  )
+  state.scroll_timer:set_repeat(next_next_time_step)
 end
 
 function neoscroll.scroll(...)
-	return neoscroll.scroll_win(0, ...)
+  return neoscroll.scroll_win(0, ...)
 end
 
 -- Wrapper for zt
 function neoscroll.zt_win(winid, half_screen_time, easing, info)
-	local window_height = vim.api.nvim_win_get_height(winid)
-	local win_lines_above_cursor = utils.getwinline(winid) - 1
-	-- Temporary fix for garbage values in local scrolloff when not set
-	local lines = win_lines_above_cursor - utils.get_scrolloff(winid, opts.use_local_scrolloff)
-	if lines == 0 then
-		return
-	end
-	local corrected_time = math.floor(
-		half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5
-	)
-	neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local win_lines_above_cursor = utils.getwinline(winid) - 1
+  -- Temporary fix for garbage values in local scrolloff when not set
+  local lines = win_lines_above_cursor - utils.get_scrolloff(winid, opts.use_local_scrolloff)
+  if lines == 0 then
+    return
+  end
+  local corrected_time =
+    math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
+  neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
 end
 
 function neoscroll.zt(half_screen_time, easing, info)
-	return neoscroll.zt_win(0, half_screen_time, easing, info)
+  return neoscroll.zt_win(0, half_screen_time, easing, info)
 end
 
 -- Wrapper for zz
 function neoscroll.zz_win(winid, half_screen_time, easing, info)
-	local window_height = vim.api.nvim_win_get_height(winid)
-	local lines = utils.getwinline(winid) - math.floor(window_height / 2 + 1)
-	if lines == 0 then
-		return
-	end
-	local corrected_time = math.floor(
-		half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5
-	)
-	neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local lines = utils.getwinline(winid) - math.floor(window_height / 2 + 1)
+  if lines == 0 then
+    return
+  end
+  local corrected_time =
+    math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
+  neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
 end
 
 function neoscroll.zz(half_screen_time, easing, info)
-	return neoscroll.zz_win(0, half_screen_time, easing, info)
+  return neoscroll.zz_win(0, half_screen_time, easing, info)
 end
 
 -- Wrapper for zb
 function neoscroll.zb_win(winid, half_screen_time, easing, info)
-	local window_height = vim.api.nvim_win_get_height(winid)
-	local lines_below_cursor = window_height - utils.getwinline(winid)
-	-- Temporary fix for garbage values in local scrolloff when not set
-	local lines = -lines_below_cursor + utils.get_scrolloff(winid, opts.use_local_scrolloff)
-	if lines == 0 then
-		return
-	end
-	local corrected_time = math.floor(
-		half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5
-	)
-	neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local lines_below_cursor = window_height - utils.getwinline(winid)
+  -- Temporary fix for garbage values in local scrolloff when not set
+  local lines = -lines_below_cursor + utils.get_scrolloff(winid, opts.use_local_scrolloff)
+  if lines == 0 then
+    return
+  end
+  local corrected_time =
+    math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
+  neoscroll.scroll_win(winid, lines, false, corrected_time, easing, info)
 end
 
 function neoscroll.zb(half_screen_time, easing, info)
-	return neoscroll.zb_win(0, half_screen_time, easing, info)
+  return neoscroll.zb_win(0, half_screen_time, easing, info)
 end
 
 function neoscroll.G_win(winid, half_screen_time, easing, info)
-	local lines = utils.get_lines_below(winid, utils.getline(winid, "w$"))
-	local window_height = vim.api.nvim_win_get_height(winid)
-	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
-	neoscroll.scroll_win(winid, lines, true, corrected_time, easing, { G = true })
+  local lines = utils.get_lines_below(winid, utils.getline(winid, "w$"))
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local corrected_time =
+    math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
+  neoscroll.scroll_win(winid, lines, true, corrected_time, easing, { G = true })
 end
 
 function neoscroll.G(half_screen_time, easing, info)
-	return neoscroll.G_win(0, half_screen_time, easing, info)
+  return neoscroll.G_win(0, half_screen_time, easing, info)
 end
 
 function neoscroll.gg_win(winid, half_screen_time, easing, info)
-	local lines = utils.get_lines_above(winid, utils.getline(winid, "w0"))
-	local window_height = vim.api.nvim_win_get_height(winid)
-	local cursor_win_line = utils.getwinline(winid)
-	lines = -lines - cursor_win_line
-	local corrected_time = math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
-	neoscroll.scroll_win(winid, lines, true, corrected_time, easing, info)
+  local lines = utils.get_lines_above(winid, utils.getline(winid, "w0"))
+  local window_height = vim.api.nvim_win_get_height(winid)
+  local cursor_win_line = utils.getwinline(winid)
+  lines = -lines - cursor_win_line
+  local corrected_time =
+    math.floor(half_screen_time * (math.abs(lines) / (window_height / 2)) + 0.5)
+  neoscroll.scroll_win(winid, lines, true, corrected_time, easing, info)
 end
 
 function neoscroll.gg(half_screen_time, easing, info)
-	return neoscroll.gg_win(0, half_screen_time, easing, info)
+  return neoscroll.gg_win(0, half_screen_time, easing, info)
 end
 
 function neoscroll.setup(custom_opts)
-	config.set_options(custom_opts)
-	opts = require("neoscroll.config").options
-	require("neoscroll.config").set_mappings()
-	vim.cmd("command! NeoscrollEnablePM let b:neoscroll_performance_mode = v:true")
-	vim.cmd("command! NeoscrollDisablePM let b:neoscroll_performance_mode = v:false")
-	vim.cmd("command! NeoscrollEnableBufferPM let b:neoscroll_performance_mode = v:true")
-	vim.cmd("command! NeoscrollDisableBufferPM let b:neoscroll_performance_mode = v:false")
-	vim.cmd("command! NeoscrollEnableGlobalPM let g:neoscroll_performance_mode = v:true")
-	vim.cmd("command! NeoscrollDisablGlobalePM let g:neoscroll_performance_mode = v:false")
-	if opts.performance_mode then
-		vim.g.neoscroll_performance_mode = true
-	end
+  config.set_options(custom_opts)
+  opts = require("neoscroll.config").options
+  require("neoscroll.config").set_mappings()
+  vim.cmd("command! NeoscrollEnablePM let b:neoscroll_performance_mode = v:true")
+  vim.cmd("command! NeoscrollDisablePM let b:neoscroll_performance_mode = v:false")
+  vim.cmd("command! NeoscrollEnableBufferPM let b:neoscroll_performance_mode = v:true")
+  vim.cmd("command! NeoscrollDisableBufferPM let b:neoscroll_performance_mode = v:false")
+  vim.cmd("command! NeoscrollEnableGlobalPM let g:neoscroll_performance_mode = v:true")
+  vim.cmd("command! NeoscrollDisablGlobalePM let g:neoscroll_performance_mode = v:false")
+  if opts.performance_mode then
+    vim.g.neoscroll_performance_mode = true
+  end
 end
 
 return neoscroll

--- a/lua/neoscroll/utils.lua
+++ b/lua/neoscroll/utils.lua
@@ -1,72 +1,83 @@
 local utils = {}
 
 -- Helper function to check if a number is a float
-function utils.is_float(n)
-	return math.floor(math.abs(n)) ~= math.abs(n)
+function utils.is_float(n) return math.floor(math.abs(n)) ~= math.abs(n) end
+
+function utils.get_lines_above(winid, line)
+  if winid ~= 0 then
+    return vim.api.nvim_win_call(winid,
+                                 function() utils.get_lines_above(0, line) end)
+  end
+  local lines_above = 0
+  local first_folded_line = vim.fn.foldclosed(line)
+  if first_folded_line ~= -1 then line = first_folded_line end
+  while line > 1 do
+    lines_above = lines_above + 1
+    line = line - 1
+    first_folded_line = vim.fn.foldclosed(line)
+    if first_folded_line ~= -1 then line = first_folded_line end
+  end
+  return lines_above
 end
 
-function utils.get_lines_above(line)
-	local lines_above = 0
-	local first_folded_line = vim.fn.foldclosed(line)
-	if first_folded_line ~= -1 then
-		line = first_folded_line
-	end
-	while line > 1 do
-		lines_above = lines_above + 1
-		line = line - 1
-		first_folded_line = vim.fn.foldclosed(line)
-		if first_folded_line ~= -1 then
-			line = first_folded_line
-		end
-	end
-	return lines_above
+function utils.get_lines_below(winid, line)
+  if winid ~= 0 then
+    return vim.api.nvim_win_call(winid,
+                                 function() utils.get_lines_below(0, line) end)
+  end
+  local last_line = vim.fn.line("$")
+  local lines_below = 0
+  local last_folded_line = vim.fn.foldclosedend(line)
+  if last_folded_line ~= -1 then line = last_folded_line end
+  while line < last_line do
+    lines_below = lines_below + 1
+    line = line + 1
+    last_folded_line = vim.fn.foldclosedend(line)
+    if last_folded_line ~= -1 then line = last_folded_line end
+  end
+  return lines_below
 end
 
-function utils.get_lines_below(line)
-	local last_line = vim.fn.line("$")
-	local lines_below = 0
-	local last_folded_line = vim.fn.foldclosedend(line)
-	if last_folded_line ~= -1 then
-		line = last_folded_line
-	end
-	while line < last_line do
-		lines_below = lines_below + 1
-		line = line + 1
-		last_folded_line = vim.fn.foldclosedend(line)
-		if last_folded_line ~= -1 then
-			line = last_folded_line
-		end
-	end
-	return lines_below
+function utils.getwinline(winid) return utils.with_winid(winid, vim.fn.winline) end
+
+function utils.with_winid(winid, fn)
+  if winid == 0 then
+    return fn()
+  else
+    return vim.api.nvim_win_call(winid, fn)
+  end
 end
 
 -- Collect all the necessary window, buffer and cursor data
 -- vim.fn.line("w0") -> if there's a fold returns first line of fold
 -- vim.fn.line("w$") -> if there's a fold returns last line of fold
-function utils.get_data()
-	local data = {}
-	data.win_top_line = vim.fn.line("w0")
-	data.win_bottom_line = vim.fn.line("w$")
-	data.last_line = vim.fn.line("$")
-	data.first_line_visible = data.win_top_line == 1
-	data.last_line_visible = data.win_bottom_line == data.last_line
-	data.window_height = vim.api.nvim_win_get_height(0)
-	data.cursor_win_line = vim.fn.winline()
-	data.win_lines_below_cursor = data.window_height - data.cursor_win_line
-	data.win_lines_above_cursor = data.cursor_win_line - 1
-	if data.last_line_visible then
-		data.lines_below_cursor = utils.get_lines_below(vim.fn.line("."))
-	end
-	return data
+function utils.get_data(winid)
+  local data = {}
+  data.win_top_line = vim.fn.line("w0", winid)
+  data.win_bottom_line = vim.fn.line("w$", winid)
+  data.last_line = vim.fn.line("$", winid)
+  data.first_line_visible = data.win_top_line == 1
+  data.last_line_visible = data.win_bottom_line == data.last_line
+  data.window_height = vim.api.nvim_win_get_height(winid)
+  data.cursor_win_line = utils.getwinline(winid)
+  data.win_lines_below_cursor = data.window_height - data.cursor_win_line
+  data.win_lines_above_cursor = data.cursor_win_line - 1
+  if data.last_line_visible then
+    data.lines_below_cursor = utils.get_lines_below(winid,
+                                                    vim.fn.line(".", winid))
+  end
+  return data
 end
 
 -- Hide/unhide cursor during scrolling for a better visual effect
+-- TODO hide only in the window we're scrolling
 function utils.hide_cursor()
   if vim.o.termguicolors and vim.o.guicursor ~= "" then
     utils.guicursor = vim.o.guicursor
     vim.o.guicursor = "a:NeoscrollHiddenCursor"
   end
 end
+
 function utils.unhide_cursor()
   if vim.o.guicursor == "a:NeoscrollHiddenCursor" then
     vim.o.guicursor = utils.guicursor
@@ -74,24 +85,22 @@ function utils.unhide_cursor()
 end
 
 -- Transforms fraction of window to number of lines
-function utils.get_lines_from_win_fraction(fraction)
-	local height_fraction = fraction * vim.api.nvim_win_get_height(0)
-	local lines
-	if height_fraction < 0 then
-		lines = -math.floor(math.abs(height_fraction) + 0.5)
-	else
-		lines = math.floor(height_fraction + 0.5)
-	end
-	return lines
+function utils.get_lines_from_win_fraction(winid, fraction)
+  local height_fraction = fraction * vim.api.nvim_win_get_height(winid)
+  local lines
+  if height_fraction < 0 then
+    lines = -math.floor(math.abs(height_fraction) + 0.5)
+  else
+    lines = math.floor(height_fraction + 0.5)
+  end
+  return lines
 end
 
-function utils.get_scrolloff()
-  local window_scrolloff = vim.wo.scrolloff
-  if window_scrolloff == -1 then
-    return vim.go.scrolloff
-  else
-    return window_scrolloff
-  end
+function utils.get_scrolloff(winid, respect_local)
+  if not respect_local then return vim.go.scrolloff end
+  local win_scrolloff = vim.api.nvim_win_get_option(winid, "scrolloff")
+  if win_scrolloff == -1 then return vim.go.scrolloff end
+  return win_scrolloff
 end
 
 return utils

--- a/lua/neoscroll/utils.lua
+++ b/lua/neoscroll/utils.lua
@@ -5,8 +5,9 @@ function utils.is_float(n) return math.floor(math.abs(n)) ~= math.abs(n) end
 
 function utils.get_lines_above(winid, line)
   if winid ~= 0 then
-    return vim.api.nvim_win_call(winid,
-                                 function() utils.get_lines_above(0, line) end)
+    return vim.api.nvim_win_call(winid, function()
+      return utils.get_lines_above(0, line)
+    end)
   end
   local lines_above = 0
   local first_folded_line = vim.fn.foldclosed(line)
@@ -22,8 +23,9 @@ end
 
 function utils.get_lines_below(winid, line)
   if winid ~= 0 then
-    return vim.api.nvim_win_call(winid,
-                                 function() utils.get_lines_below(0, line) end)
+    return vim.api.nvim_win_call(winid, function()
+      return utils.get_lines_below(0, line)
+    end)
   end
   local last_line = vim.fn.line("$")
   local lines_below = 0
@@ -40,6 +42,16 @@ end
 
 function utils.getwinline(winid) return utils.with_winid(winid, vim.fn.winline) end
 
+function utils.getline(winid, marker)
+  if winid == 0 then return vim.fn.line(marker) end
+  return vim.fn.line(marker)
+end
+
+function utils.getline(winid, marker)
+  if winid == 0 then return vim.fn.line(marker) end
+  return vim.fn.line(marker)
+end
+
 function utils.with_winid(winid, fn)
   if winid == 0 then
     return fn()
@@ -53,9 +65,9 @@ end
 -- vim.fn.line("w$") -> if there's a fold returns last line of fold
 function utils.get_data(winid)
   local data = {}
-  data.win_top_line = vim.fn.line("w0", winid)
-  data.win_bottom_line = vim.fn.line("w$", winid)
-  data.last_line = vim.fn.line("$", winid)
+  data.win_top_line = utils.getline(winid, "w0")
+  data.win_bottom_line = utils.getline(winid, "w$")
+  data.last_line = utils.getline(winid, "$")
   data.first_line_visible = data.win_top_line == 1
   data.last_line_visible = data.win_bottom_line == data.last_line
   data.window_height = vim.api.nvim_win_get_height(winid)
@@ -64,7 +76,7 @@ function utils.get_data(winid)
   data.win_lines_above_cursor = data.cursor_win_line - 1
   if data.last_line_visible then
     data.lines_below_cursor = utils.get_lines_below(winid,
-                                                    vim.fn.line(".", winid))
+                                                    utils.getline(winid, "."))
   end
   return data
 end

--- a/lua/neoscroll/utils.lua
+++ b/lua/neoscroll/utils.lua
@@ -1,7 +1,9 @@
 local utils = {}
 
 -- Helper function to check if a number is a float
-function utils.is_float(n) return math.floor(math.abs(n)) ~= math.abs(n) end
+function utils.is_float(n)
+  return math.floor(math.abs(n)) ~= math.abs(n)
+end
 
 function utils.get_lines_above(winid, line)
   if winid ~= 0 then
@@ -11,12 +13,16 @@ function utils.get_lines_above(winid, line)
   end
   local lines_above = 0
   local first_folded_line = vim.fn.foldclosed(line)
-  if first_folded_line ~= -1 then line = first_folded_line end
+  if first_folded_line ~= -1 then
+    line = first_folded_line
+  end
   while line > 1 do
     lines_above = lines_above + 1
     line = line - 1
     first_folded_line = vim.fn.foldclosed(line)
-    if first_folded_line ~= -1 then line = first_folded_line end
+    if first_folded_line ~= -1 then
+      line = first_folded_line
+    end
   end
   return lines_above
 end
@@ -30,25 +36,35 @@ function utils.get_lines_below(winid, line)
   local last_line = vim.fn.line("$")
   local lines_below = 0
   local last_folded_line = vim.fn.foldclosedend(line)
-  if last_folded_line ~= -1 then line = last_folded_line end
+  if last_folded_line ~= -1 then
+    line = last_folded_line
+  end
   while line < last_line do
     lines_below = lines_below + 1
     line = line + 1
     last_folded_line = vim.fn.foldclosedend(line)
-    if last_folded_line ~= -1 then line = last_folded_line end
+    if last_folded_line ~= -1 then
+      line = last_folded_line
+    end
   end
   return lines_below
 end
 
-function utils.getwinline(winid) return utils.with_winid(winid, vim.fn.winline) end
+function utils.getwinline(winid)
+  return utils.with_winid(winid, vim.fn.winline)
+end
 
 function utils.getline(winid, marker)
-  if winid == 0 then return vim.fn.line(marker) end
+  if winid == 0 then
+    return vim.fn.line(marker)
+  end
   return vim.fn.line(marker)
 end
 
 function utils.getline(winid, marker)
-  if winid == 0 then return vim.fn.line(marker) end
+  if winid == 0 then
+    return vim.fn.line(marker)
+  end
   return vim.fn.line(marker, winid)
 end
 
@@ -75,8 +91,7 @@ function utils.get_data(winid)
   data.win_lines_below_cursor = data.window_height - data.cursor_win_line
   data.win_lines_above_cursor = data.cursor_win_line - 1
   if data.last_line_visible then
-    data.lines_below_cursor = utils.get_lines_below(winid,
-                                                    utils.getline(winid, "."))
+    data.lines_below_cursor = utils.get_lines_below(winid, utils.getline(winid, "."))
   end
   return data
 end
@@ -109,9 +124,13 @@ function utils.get_lines_from_win_fraction(winid, fraction)
 end
 
 function utils.get_scrolloff(winid, respect_local)
-  if not respect_local then return vim.go.scrolloff end
+  if not respect_local then
+    return vim.go.scrolloff
+  end
   local win_scrolloff = vim.api.nvim_win_get_option(winid, "scrolloff")
-  if win_scrolloff == -1 then return vim.go.scrolloff end
+  if win_scrolloff == -1 then
+    return vim.go.scrolloff
+  end
   return win_scrolloff
 end
 

--- a/lua/neoscroll/utils.lua
+++ b/lua/neoscroll/utils.lua
@@ -49,7 +49,7 @@ end
 
 function utils.getline(winid, marker)
   if winid == 0 then return vim.fn.line(marker) end
-  return vim.fn.line(marker)
+  return vim.fn.line(marker, winid)
 end
 
 function utils.with_winid(winid, fn)

--- a/lua/tests/cursor_scrolls_alone_spec.lua
+++ b/lua/tests/cursor_scrolls_alone_spec.lua
@@ -4,10 +4,10 @@ describe("When EOF is reached", function()
   local time_tol = 5
   local lines = 7
   neoscroll = require("neoscroll")
-  vim.api.nvim_command('help help | only')
+  vim.api.nvim_command("help help | only")
 
   before_each(function()
-    vim.api.nvim_command('normal ggGM')
+    vim.api.nvim_command("normal ggGM")
     time = 100
     time_tol = 5
     lines = 7
@@ -16,7 +16,7 @@ describe("When EOF is reached", function()
   end)
 
   it("should scroll cursor when cursor_scrolls_alone==true", function()
-    neoscroll.setup({stop_eof = true, cursor_scrolls_alone = true})
+    neoscroll.setup({ stop_eof = true, cursor_scrolls_alone = true })
     -- Scroll forwards
     -- print('window line:', vim.fn.winline())
     neoscroll.scroll(lines, true, time)
@@ -29,7 +29,7 @@ describe("When EOF is reached", function()
   end)
 
   it("should not scroll cursor when cursor_scrolls_alone==false", function()
-    neoscroll.setup({stop_eof = true, cursor_scrolls_alone = false})
+    neoscroll.setup({ stop_eof = true, cursor_scrolls_alone = false })
     -- Scroll forwards
     neoscroll.scroll(lines, true, time)
     vim.wait(time + time_tol)
@@ -38,5 +38,4 @@ describe("When EOF is reached", function()
     assert.equals(cursor_start, cursor_finish)
     assert.equals(window_start, window_finish)
   end)
-
 end)

--- a/lua/tests/respect_scrolloff_spec.lua
+++ b/lua/tests/respect_scrolloff_spec.lua
@@ -64,6 +64,7 @@ describe("When BOF is reached", function()
       vim.go.scrolloff = 0
       vim.wo.scrolloff = scrolloff
       opts.respect_scrolloff = true
+      opts.use_local_scrolloff = true
       neoscroll.setup(opts)
       -- scroll forwards
       neoscroll.scroll(-(cursor_start - 1), true, time)

--- a/lua/tests/respect_scrolloff_spec.lua
+++ b/lua/tests/respect_scrolloff_spec.lua
@@ -2,12 +2,12 @@ describe("When BOF is reached", function()
   local neoscroll, cursor_start, cursor_finish, window_start, window_finish
   local time = 100
   local time_tol = 5
-  local opts = {stop_eof = true, cursor_scrolls_alone = true}
+  local opts = { stop_eof = true, cursor_scrolls_alone = true }
   neoscroll = require("neoscroll")
-  vim.api.nvim_command('help help | only')
+  vim.api.nvim_command("help help | only")
 
   before_each(function()
-    vim.api.nvim_command('normal ggM')
+    vim.api.nvim_command("normal ggM")
     cursor_start = vim.fn.line(".")
     window_start = vim.fn.line("w0")
   end)
@@ -18,7 +18,7 @@ describe("When BOF is reached", function()
     opts.respect_scrolloff = false
     neoscroll.setup(opts)
     -- Scroll forwards
-    neoscroll.scroll(-(cursor_start-1), true, time)
+    neoscroll.scroll(-(cursor_start - 1), true, time)
     vim.wait(time + time_tol)
     cursor_finish = vim.fn.line(".")
     window_finish = vim.fn.line("w0")
@@ -32,7 +32,7 @@ describe("When BOF is reached", function()
     opts.respect_scrolloff = true
     neoscroll.setup(opts)
     -- Scroll forwards
-    neoscroll.scroll(-(cursor_start-1), true, time)
+    neoscroll.scroll(-(cursor_start - 1), true, time)
     vim.wait(time + time_tol)
     cursor_finish = vim.fn.line(".")
     window_finish = vim.fn.line("w0")
@@ -40,49 +40,54 @@ describe("When BOF is reached", function()
     assert.equals(window_start, window_finish)
   end)
 
-  it("should not scroll cursor till top when respect_scrolloff==true and go.scrolloff==5", function()
-    local scrolloff = 5
-    vim.go.scrolloff = scrolloff
-    opts.respect_scrolloff = true
-    neoscroll.setup(opts)
-    -- scroll forwards
-    neoscroll.scroll(-(cursor_start-1), true, time)
-    vim.wait(time + time_tol)
-    cursor_finish = vim.fn.line(".")
-    window_finish = vim.fn.line("w0")
-    assert.equals(scrolloff + 1, cursor_finish)
-    assert.equals(window_start, window_finish)
-  end)
+  it(
+    "should not scroll cursor till top when respect_scrolloff==true and go.scrolloff==5",
+    function()
+      local scrolloff = 5
+      vim.go.scrolloff = scrolloff
+      opts.respect_scrolloff = true
+      neoscroll.setup(opts)
+      -- scroll forwards
+      neoscroll.scroll(-(cursor_start - 1), true, time)
+      vim.wait(time + time_tol)
+      cursor_finish = vim.fn.line(".")
+      window_finish = vim.fn.line("w0")
+      assert.equals(scrolloff + 1, cursor_finish)
+      assert.equals(window_start, window_finish)
+    end
+  )
 
-  it("should not scroll cursor till top when respect_scrolloff==true and wo.scrolloff==5", function()
-    local scrolloff = 5
-    vim.go.scrolloff = 0
-    vim.wo.scrolloff = scrolloff
-    opts.respect_scrolloff = true
-    neoscroll.setup(opts)
-    -- scroll forwards
-    neoscroll.scroll(-(cursor_start-1), true, time)
-    vim.wait(time + time_tol)
-    cursor_finish = vim.fn.line(".")
-    window_finish = vim.fn.line("w0")
-    assert.equals(scrolloff + 1, cursor_finish)
-    assert.equals(window_start, window_finish)
-  end)
-
+  it(
+    "should not scroll cursor till top when respect_scrolloff==true and wo.scrolloff==5",
+    function()
+      local scrolloff = 5
+      vim.go.scrolloff = 0
+      vim.wo.scrolloff = scrolloff
+      opts.respect_scrolloff = true
+      neoscroll.setup(opts)
+      -- scroll forwards
+      neoscroll.scroll(-(cursor_start - 1), true, time)
+      vim.wait(time + time_tol)
+      cursor_finish = vim.fn.line(".")
+      window_finish = vim.fn.line("w0")
+      assert.equals(scrolloff + 1, cursor_finish)
+      assert.equals(window_start, window_finish)
+    end
+  )
 end)
 
 describe("When EOF is reached", function()
   local neoscroll, cursor_start, cursor_finish, window_start, window_finish
   local time = 100
   local time_tol = 5
-  local opts = {stop_eof = true, cursor_scrolls_alone = true}
+  local opts = { stop_eof = true, cursor_scrolls_alone = true }
   local last_line = vim.fn.line("$")
   local lines
   vim.wo.scrolloff = -1
   neoscroll = require("neoscroll")
 
   before_each(function()
-    vim.api.nvim_command('normal ggGM')
+    vim.api.nvim_command("normal ggGM")
     -- vim.api.nvim_command([[exec "normal! \<c-e>"]])
     cursor_start = vim.fn.line(".")
     window_start = vim.fn.line("w0")
@@ -117,48 +122,54 @@ describe("When EOF is reached", function()
     assert.equals(window_start, window_finish)
   end)
 
-  it("should not scroll cursor till top when respect_scrolloff==true and go.scrolloff==5", function()
-    local scrolloff = 5
-    vim.go.scrolloff = scrolloff
-    opts.respect_scrolloff = true
-    neoscroll.setup(opts)
-    -- Scroll forwards
-    neoscroll.scroll(lines, true, time)
-    vim.wait(time + time_tol)
-    cursor_finish = vim.fn.line(".")
-    window_finish = vim.fn.line("w0")
-    assert.equals(last_line - scrolloff, cursor_finish)
-    assert.equals(window_start, window_finish)
-  end)
+  it(
+    "should not scroll cursor till top when respect_scrolloff==true and go.scrolloff==5",
+    function()
+      local scrolloff = 5
+      vim.go.scrolloff = scrolloff
+      opts.respect_scrolloff = true
+      neoscroll.setup(opts)
+      -- Scroll forwards
+      neoscroll.scroll(lines, true, time)
+      vim.wait(time + time_tol)
+      cursor_finish = vim.fn.line(".")
+      window_finish = vim.fn.line("w0")
+      assert.equals(last_line - scrolloff, cursor_finish)
+      assert.equals(window_start, window_finish)
+    end
+  )
 
-  it("should not scroll cursor till top when respect_scrolloff==true and wo.scrolloff==5", function()
-    local scrolloff = 5
-    vim.go.scrolloff = 0
-    vim.wo.scrolloff = scrolloff
-    opts.respect_scrolloff = true
-    neoscroll.setup(opts)
-    -- Scroll forwards
-    neoscroll.scroll(lines, true, time)
-    vim.wait(time + time_tol)
-    cursor_finish = vim.fn.line(".")
-    window_finish = vim.fn.line("w0")
-    assert.equals(last_line - scrolloff, cursor_finish)
-    assert.equals(window_start, window_finish)
-  end)
+  it(
+    "should not scroll cursor till top when respect_scrolloff==true and wo.scrolloff==5",
+    function()
+      local scrolloff = 5
+      vim.go.scrolloff = 0
+      vim.wo.scrolloff = scrolloff
+      opts.respect_scrolloff = true
+      neoscroll.setup(opts)
+      -- Scroll forwards
+      neoscroll.scroll(lines, true, time)
+      vim.wait(time + time_tol)
+      cursor_finish = vim.fn.line(".")
+      window_finish = vim.fn.line("w0")
+      assert.equals(last_line - scrolloff, cursor_finish)
+      assert.equals(window_start, window_finish)
+    end
+  )
 end)
 
 describe("When beyond EOF", function()
   local neoscroll, cursor_start, cursor_finish, window_start, window_finish
   local time = 100
   local time_tol = 5
-  local opts = {stop_eof = true, cursor_scrolls_alone = true}
+  local opts = { stop_eof = true, cursor_scrolls_alone = true }
   local lines = vim.fn.winheight(0)
   vim.wo.scrolloff = -1
   neoscroll = require("neoscroll")
   local last_line = vim.fn.line("$")
 
   before_each(function()
-    vim.api.nvim_command('normal ggGM')
+    vim.api.nvim_command("normal ggGM")
     vim.api.nvim_command([[exec "normal! \<c-e>"]])
     cursor_start = vim.fn.line(".")
     window_start = vim.fn.line("w0")
@@ -175,7 +186,7 @@ describe("When beyond EOF", function()
     cursor_finish = vim.fn.line(".")
     window_finish = vim.fn.line("w0")
     assert.equals(last_line, cursor_finish)
-    assert.equals(window_start + (cursor_finish - cursor_start) , window_finish)
+    assert.equals(window_start + (cursor_finish - cursor_start), window_finish)
   end)
 
   it("should scroll cursor till top when respect_scrolloff==true and go.scrolloff==0", function()
@@ -189,35 +200,41 @@ describe("When beyond EOF", function()
     cursor_finish = vim.fn.line(".")
     window_finish = vim.fn.line("w0")
     assert.equals(last_line, cursor_finish)
-    assert.equals(window_start + (cursor_finish - cursor_start) , window_finish)
+    assert.equals(window_start + (cursor_finish - cursor_start), window_finish)
   end)
 
-  it("should not scroll cursor till top when respect_scrolloff==true and go.scrolloff==5", function()
-    local scrolloff = 5
-    vim.go.scrolloff = scrolloff
-    opts.respect_scrolloff = true
-    neoscroll.setup(opts)
-    -- Scroll forwards
-    neoscroll.scroll(lines, true, time)
-    vim.wait(time + time_tol)
-    cursor_finish = vim.fn.line(".")
-    window_finish = vim.fn.line("w0")
-    assert.equals(last_line - scrolloff, cursor_finish)
-    assert.equals(window_start + (cursor_finish - cursor_start) , window_finish)
-  end)
+  it(
+    "should not scroll cursor till top when respect_scrolloff==true and go.scrolloff==5",
+    function()
+      local scrolloff = 5
+      vim.go.scrolloff = scrolloff
+      opts.respect_scrolloff = true
+      neoscroll.setup(opts)
+      -- Scroll forwards
+      neoscroll.scroll(lines, true, time)
+      vim.wait(time + time_tol)
+      cursor_finish = vim.fn.line(".")
+      window_finish = vim.fn.line("w0")
+      assert.equals(last_line - scrolloff, cursor_finish)
+      assert.equals(window_start + (cursor_finish - cursor_start), window_finish)
+    end
+  )
 
-  it("should not scroll cursor till top when respect_scrolloff==true and wo.scrolloff==5", function()
-    local scrolloff = 5
-    vim.go.scrolloff = 0
-    vim.wo.scrolloff = scrolloff
-    opts.respect_scrolloff = true
-    neoscroll.setup(opts)
-    -- Scroll forwards
-    neoscroll.scroll(lines, true, time)
-    vim.wait(time + time_tol)
-    cursor_finish = vim.fn.line(".")
-    window_finish = vim.fn.line("w0")
-    assert.equals(last_line - scrolloff, cursor_finish)
-    assert.equals(window_start + (cursor_finish - cursor_start) , window_finish)
-  end)
+  it(
+    "should not scroll cursor till top when respect_scrolloff==true and wo.scrolloff==5",
+    function()
+      local scrolloff = 5
+      vim.go.scrolloff = 0
+      vim.wo.scrolloff = scrolloff
+      opts.respect_scrolloff = true
+      neoscroll.setup(opts)
+      -- Scroll forwards
+      neoscroll.scroll(lines, true, time)
+      vim.wait(time + time_tol)
+      cursor_finish = vim.fn.line(".")
+      window_finish = vim.fn.line("w0")
+      assert.equals(last_line - scrolloff, cursor_finish)
+      assert.equals(window_start + (cursor_finish - cursor_start), window_finish)
+    end
+  )
 end)

--- a/lua/tests/scroll_bottom_spec.lua
+++ b/lua/tests/scroll_bottom_spec.lua
@@ -26,7 +26,6 @@ local function scroll_win_cursor(scrolloff)
   if not scrolloff then
     assert.equals(cursor_start, cursor_finish)
   end
-
 end
 
 local motion_opts = {
@@ -37,18 +36,18 @@ local motion_opts = {
 
 describe("Scrolls from bottom without scrolloff", function()
   local neoscroll = require("neoscroll")
-  vim.api.nvim_command('help help | only')
+  vim.api.nvim_command("help help | only")
 
   before_each(function()
-    vim.api.nvim_command('normal ggG')
+    vim.api.nvim_command("normal ggG")
   end)
 
   for opt1, val1 in pairs(motion_opts) do
-    local custom_opts = {[opt1] = val1}
+    local custom_opts = { [opt1] = val1 }
     for opt2, val2 in pairs(motion_opts) do
       custom_opts[opt2] = val2
       for opt3, val3 in pairs(motion_opts) do
-        custom_opts[opt3]  = val3
+        custom_opts[opt3] = val3
         it(vim.inspect(custom_opts), function()
           neoscroll.setup(custom_opts)
           scroll_win_cursor(vim.go.scrolloff ~= 0)
@@ -63,15 +62,15 @@ describe("Scrolls from bottom with scrolloff", function()
   vim.go.scrolloff = 3
 
   before_each(function()
-    vim.api.nvim_command('normal ggG')
+    vim.api.nvim_command("normal ggG")
   end)
 
   for opt1, val1 in pairs(motion_opts) do
-    local custom_opts = {[opt1] = val1}
+    local custom_opts = { [opt1] = val1 }
     for opt2, val2 in pairs(motion_opts) do
       custom_opts[opt2] = val2
       for opt3, val3 in pairs(motion_opts) do
-        custom_opts[opt3]  = val3
+        custom_opts[opt3] = val3
         it(vim.inspect(custom_opts), function()
           neoscroll.setup(custom_opts)
           scroll_win_cursor(vim.go.scrolloff ~= 0)

--- a/lua/tests/scroll_spec.lua
+++ b/lua/tests/scroll_spec.lua
@@ -30,22 +30,21 @@ local motion_opts = {
   cursor_scrolls_alone = false,
 }
 
-
 describe("Scrolls properly with", function()
   local neoscroll = require("neoscroll")
   vim.go.scrolloff = 3
-  vim.api.nvim_command('help help | only')
+  vim.api.nvim_command("help help | only")
 
   before_each(function()
-    vim.api.nvim_command('normal ggM')
+    vim.api.nvim_command("normal ggM")
   end)
 
   for opt1, val1 in pairs(motion_opts) do
-    local custom_opts = {[opt1] = val1}
+    local custom_opts = { [opt1] = val1 }
     for opt2, val2 in pairs(motion_opts) do
       custom_opts[opt2] = val2
       for opt3, val3 in pairs(motion_opts) do
-        custom_opts[opt3]  = val3
+        custom_opts[opt3] = val3
         it(vim.inspect(custom_opts), function()
           neoscroll.setup(custom_opts)
           scroll_win_cursor()
@@ -53,6 +52,4 @@ describe("Scrolls properly with", function()
       end
     end
   end
-
-
 end)

--- a/lua/tests/scroll_top_spec.lua
+++ b/lua/tests/scroll_top_spec.lua
@@ -23,9 +23,9 @@ local function scroll_win_cursor(scrolloff)
   cursor_finish = vim.fn.line(".")
   window_finish = vim.fn.line("w0")
   assert.equals(window_start, window_finish)
-if not scrolloff then
-  assert.equals(cursor_start, cursor_finish)
-end
+  if not scrolloff then
+    assert.equals(cursor_start, cursor_finish)
+  end
 end
 
 local motion_opts = {
@@ -36,18 +36,18 @@ local motion_opts = {
 
 describe("Scrolls from top without scrolloff", function()
   local neoscroll = require("neoscroll")
-  vim.api.nvim_command('help help | only')
+  vim.api.nvim_command("help help | only")
 
   before_each(function()
-    vim.api.nvim_command('normal gg')
+    vim.api.nvim_command("normal gg")
   end)
 
   for opt1, val1 in pairs(motion_opts) do
-    local custom_opts = {[opt1] = val1}
+    local custom_opts = { [opt1] = val1 }
     for opt2, val2 in pairs(motion_opts) do
       custom_opts[opt2] = val2
       for opt3, val3 in pairs(motion_opts) do
-        custom_opts[opt3]  = val3
+        custom_opts[opt3] = val3
         it(vim.inspect(custom_opts), function()
           neoscroll.setup(custom_opts)
           scroll_win_cursor(vim.go.scrolloff ~= 0)
@@ -62,15 +62,15 @@ describe("Scrolls from top with scrolloff", function()
   vim.go.scrolloff = 3
 
   before_each(function()
-    vim.api.nvim_command('normal gg')
+    vim.api.nvim_command("normal gg")
   end)
 
   for opt1, val1 in pairs(motion_opts) do
-    local custom_opts = {[opt1] = val1}
+    local custom_opts = { [opt1] = val1 }
     for opt2, val2 in pairs(motion_opts) do
       custom_opts[opt2] = val2
       for opt3, val3 in pairs(motion_opts) do
-        custom_opts[opt3]  = val3
+        custom_opts[opt3] = val3
         it(vim.inspect(custom_opts), function()
           neoscroll.setup(custom_opts)
           scroll_win_cursor(vim.go.scrolloff ~= 0)

--- a/lua/tests/scroll_window_spec.lua
+++ b/lua/tests/scroll_window_spec.lua
@@ -30,22 +30,21 @@ local motion_opts = {
   cursor_scrolls_alone = false,
 }
 
-
 describe("Scrolls properly with", function()
   local neoscroll = require("neoscroll")
   vim.go.scrolloff = 3
-  vim.api.nvim_command('help help | only')
+  vim.api.nvim_command("help help | only")
 
   before_each(function()
-    vim.api.nvim_command('normal ggM')
+    vim.api.nvim_command("normal ggM")
   end)
 
   for opt1, val1 in pairs(motion_opts) do
-    local custom_opts = {[opt1] = val1}
+    local custom_opts = { [opt1] = val1 }
     for opt2, val2 in pairs(motion_opts) do
       custom_opts[opt2] = val2
       for opt3, val3 in pairs(motion_opts) do
-        custom_opts[opt3]  = val3
+        custom_opts[opt3] = val3
         it(vim.inspect(custom_opts), function()
           neoscroll.setup(custom_opts)
           scroll_win_cursor()
@@ -53,6 +52,4 @@ describe("Scrolls properly with", function()
       end
     end
   end
-
-
 end)

--- a/lua/tests/stop_eof_spec.lua
+++ b/lua/tests/stop_eof_spec.lua
@@ -4,16 +4,16 @@ describe("When EOF is reached", function()
   local time_tol = 5
   local lines = 7
   neoscroll = require("neoscroll")
-  vim.api.nvim_command('help help | only')
+  vim.api.nvim_command("help help | only")
 
   before_each(function()
-    vim.api.nvim_command('normal ggGM')
+    vim.api.nvim_command("normal ggGM")
     cursor_start = vim.fn.line(".")
     window_start = vim.fn.line("w0")
   end)
 
   it("should not scroll window further when stop_eof==true", function()
-    neoscroll.setup({stop_eof = true})
+    neoscroll.setup({ stop_eof = true })
     -- Scroll forwards
     -- print('window line:', vim.fn.winline())
     neoscroll.scroll(lines, true, time)
@@ -26,7 +26,7 @@ describe("When EOF is reached", function()
   end)
 
   it("should not scroll window further when stop_eof==false", function()
-    neoscroll.setup({stop_eof = false})
+    neoscroll.setup({ stop_eof = false })
     -- Scroll forwards
     neoscroll.scroll(lines, true, time)
     vim.wait(time + time_tol)
@@ -35,5 +35,4 @@ describe("When EOF is reached", function()
     assert.equals(cursor_start + lines, cursor_finish)
     assert.equals(window_start + lines, window_finish)
   end)
-
 end)

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,6 @@
+column_width = 100
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"


### PR DESCRIPTION
Added `neoscroll.*_win` functions that have the same signature, but take an additional winid parameter.

That required some refactoring:
1. Most util functions now take a winid parameter
2. State is now stored in WindowState[winid] instead of module-level variables

Unfortunately, some functions do not have a per-winid alternatives (namely, `winline`, `foldclosed`, `foldclosedend`) - or at least I'm not aware of them. For these functions, I do `vim.api.nvim_win_call(fn)`, which may (or may not) impact performance. For scrolling current window, nothing changed.

I didn't check the performance impact of calling a bunch of functions in `nvim_win_call` - if it's large, it may make sense to just call the whole callback inside of it and work with `winid=0` everywhere else. I don't know if being inside `nvim_win_call` for a long time may have other side effects though. 

I did some manual testing, everything seems to work the same way it did. Attaching videos (one recorded with the master branch, one recorded with this PR). Apologies for potato quality, GitHub doesn't like big files, and my Firefox doesn't like HEVC.
Also tested closing the window mid-scroll, though that's not in the recording.

If there any other tests/benchmarks I can run (automatic or manual), please let me know.


https://user-images.githubusercontent.com/18747677/174565698-576a61b0-07e8-4dfd-ba84-4f0fbb61f525.mp4


https://user-images.githubusercontent.com/18747677/174565208-54563c7e-ae79-404a-997d-9a13fd40629e.mp4

