### PR TITLE
Add time_scale option

### DIFF
--- a/lua/neoscroll/config.lua
+++ b/lua/neoscroll/config.lua
@@ -7,6 +7,7 @@ config.options = {
 	respect_scrolloff = false,
 	cursor_scrolls_alone = true,
 	performance_mode = false,
+	time_scale = 1.0,
 }
 
 function config.set_options(custom_opts)

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -224,6 +224,7 @@ local neoscroll = {}
 -- move_cursor: scroll the window and the cursor simultaneously
 -- easing_function: name of the easing function to use for the scrolling animation
 function neoscroll.scroll(lines, move_cursor, time, easing_function, info)
+	time = time * config.options.time_scale
 	-- If lines is a fraction of the window transform it to lines
 	if utils.is_float(lines) then
 		lines = utils.get_lines_from_win_fraction(lines)


### PR DESCRIPTION
Add an option to adjust the time of scroll animations. Can be used to easily speed up or slow down all scroll animations.