### PR TITLE
Fixed zz doesn't center the due to wrapped line

### DIFF
--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -29,9 +29,9 @@ local function scroll_up(data, scroll_window, scroll_cursor, n_repeat)
 	local cursor_scroll_input = scroll_cursor and string.rep("gk", n) or ""
 	local window_scroll_input = scroll_window and [[\<C-y>]] or ""
 	local scroll_input
-  -- if scrolloff or window edge are going to move the cursor for you then only
-  -- scroll the window
-  if
+	-- if scrolloff or window edge are going to move the cursor for you then only
+	-- scroll the window
+	if
 		(
 			(
 				data.last_line_visible
@@ -52,8 +52,8 @@ local function scroll_down(data, scroll_window, scroll_cursor, n_repeat)
 	local cursor_scroll_input = scroll_cursor and string.rep("gj", n) or ""
 	local window_scroll_input = scroll_window and [[\<C-e>]] or ""
 	local scroll_input
-  -- if scrolloff or window edge are going to move the cursor for you then only
-  -- scroll the window
+	-- if scrolloff or window edge are going to move the cursor for you then only
+	-- scroll the window
 	if
 		(
 			(data.first_line_visible and data.win_lines_above_cursor <= utils.get_scrolloff())
@@ -106,16 +106,16 @@ end
 -- Check if the window and the cursor can be scrolled further
 local function who_scrolls(data, move_cursor, direction)
 	local scroll_window, scroll_cursor
-  local half_window = math.floor(data.window_height/2)
+	local half_window = math.floor(data.window_height / 2)
 	scroll_window = not window_reached_limit(data, move_cursor, direction)
 	if not move_cursor then
 		scroll_cursor = false
 	elseif scroll_window then
-    if utils.get_scrolloff() < half_window then
-      scroll_cursor = true
-    else
-      scroll_cursor = false
-    end
+		if utils.get_scrolloff() < half_window then
+			scroll_cursor = true
+		else
+			scroll_cursor = false
+		end
 	elseif opts.cursor_scrolls_alone then
 		scroll_cursor = not cursor_reached_limit(data)
 	else
@@ -253,9 +253,9 @@ function neoscroll.scroll(lines, move_cursor, time, easing_function, info)
 	end
 	-- Check if the window and the cursor are allowed to scroll in that direction
 	local data = utils.get_data()
-  local half_window = math.floor(data.window_height/2)
-  if utils.get_scrolloff() >= half_window then
-    cursor_win_line = half_window
+	local half_window = math.floor(data.window_height / 2)
+	if utils.get_scrolloff() >= half_window then
+		cursor_win_line = half_window
 	elseif data.win_lines_above_cursor <= utils.get_scrolloff() then
 		cursor_win_line = utils.get_scrolloff() + 1
 	elseif data.win_lines_below_cursor <= utils.get_scrolloff() then
@@ -299,10 +299,10 @@ function neoscroll.scroll(lines, move_cursor, time, easing_function, info)
 			-- sets the repeat of the next cycle
 			scroll_timer:set_repeat(next_time_step)
 		end
-    if math.abs(lines_to_scroll) == 0 then
-      stop_scrolling(move_cursor, info)
-      return
-    end
+		if math.abs(lines_to_scroll) == 0 then
+			stop_scrolling(move_cursor, info)
+			return
+		end
 		scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, data)
 		if math.abs(lines_to_scroll) == 1 then
 			stop_scrolling(move_cursor, info)

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -127,7 +127,7 @@ end
 -- Scroll one line in the given direction
 local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, data)
 	local winline_before = vim.fn.winline()
-	local curpos_line_before = vim.fn.getcurpos()[2]
+	local curpos_line_before = vim.api.nvim_win_get_cursor(0)[1]
 	local scroll
 	local scrolled_lines
 	if lines_to_scroll > 0 then
@@ -146,7 +146,7 @@ local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, da
 	if scroll_cursor and scroll_window and lines_behind > 0 then
 		vim.cmd(scroll(data, false, scroll_cursor, lines_behind))
 	end
-	if curpos_line_before == vim.fn.getcurpos()[2] then
+	if curpos_line_before == vim.api.nvim_win_get_cursor(0)[1] then
 		-- if curpos_line didn't change, we can use it to get scrolled_lines
 		-- This is more accurate when some lines are wrapped
 		scrolled_lines = winline_before - vim.fn.winline()

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -139,7 +139,10 @@ local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, da
 	end
 	vim.cmd(scroll(data, scroll_window, scroll_cursor))
 	-- Correct for wrapped lines
-	local lines_behind = math.abs(vim.fn.winline() - cursor_win_line)
+	local lines_behind = vim.fn.winline() - cursor_win_line
+	if lines_to_scroll > 0 then
+		lines_behind = -lines_behind
+	end
 	if scroll_cursor and scroll_window and lines_behind > 0 then
 		vim.cmd(scroll(data, false, scroll_cursor, lines_behind))
 	end

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -126,7 +126,7 @@ end
 
 -- Scroll one line in the given direction
 local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, data)
-	local winline_before = vim.fn.winline() -- record for later
+	local winline_before = vim.fn.winline()
 	local curpos_line_before = vim.fn.getcurpos()[2]
 	local scroll
 	local scrolled_lines
@@ -145,8 +145,8 @@ local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, da
 			vim.cmd(scroll(data, false, scroll_cursor, lines_behind))
 		end
 	elseif curpos_line_before == vim.fn.getcurpos()[2] then
-		-- if curpos_line didn't change, we can check it to see if it scroll more
-		-- than it should due to wrapped line
+		-- if curpos_line didn't change, we can use it to get scrolled_lines
+		-- This is more accurate when some lines are wrapped
 		scrolled_lines = winline_before - vim.fn.winline()
 	end
 	relative_line = relative_line + scrolled_lines

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -127,6 +127,7 @@ end
 -- Scroll one line in the given direction
 local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, data)
 	local winline_before = vim.fn.winline() -- record for later
+	local curpos_line_before = vim.fn.getcurpos()[2]
 	local scroll
 	local scrolled_lines
 	if lines_to_scroll > 0 then
@@ -143,7 +144,9 @@ local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, da
 		if lines_behind > 0 then
 			vim.cmd(scroll(data, false, scroll_cursor, lines_behind))
 		end
-	elseif scroll_window then
+	elseif curpos_line_before == vim.fn.getcurpos()[2] then
+		-- if curpos_line didn't change, we can check it to see if it scroll more
+		-- than it should due to wrapped line
 		scrolled_lines = winline_before - vim.fn.winline()
 	end
 	relative_line = relative_line + scrolled_lines

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -126,23 +126,27 @@ end
 
 -- Scroll one line in the given direction
 local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, data)
+	local winline_before = vim.fn.winline() -- record for later
+	local scroll
+	local scrolled_lines
 	if lines_to_scroll > 0 then
-		relative_line = relative_line + 1
-		vim.cmd(scroll_down(data, scroll_window, scroll_cursor))
-		-- Correct for wrapped lines
-		local lines_behind = cursor_win_line - vim.fn.winline()
-		if scroll_cursor and scroll_window and lines_behind > 0 then
-			vim.cmd(scroll_down(data, false, scroll_cursor, lines_behind))
-		end
+		scrolled_lines = 1
+		scroll = scroll_down
 	else
-		relative_line = relative_line - 1
-		vim.cmd(scroll_up(data, scroll_window, scroll_cursor))
-		-- Correct for wrapped lines
-		local lines_behind = vim.fn.winline() - cursor_win_line
-		if scroll_cursor and scroll_window and lines_behind > 0 then
-			vim.cmd(scroll_up(data, false, scroll_cursor, lines_behind))
-		end
+		scrolled_lines = -1
+		scroll = scroll_up
 	end
+	vim.cmd(scroll(data, scroll_window, scroll_cursor))
+	-- Correct for wrapped lines
+	if scroll_cursor and scroll_window then
+		local lines_behind = math.abs(vim.fn.winline() - cursor_win_line)
+		if lines_behind > 0 then
+			vim.cmd(scroll(data, false, scroll_cursor, lines_behind))
+		end
+	elseif scroll_window then
+		scrolled_lines = winline_before - vim.fn.winline()
+	end
+	relative_line = relative_line + scrolled_lines
 end
 
 -- Scrolling constructor

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -139,12 +139,11 @@ local function scroll_one_line(lines_to_scroll, scroll_window, scroll_cursor, da
 	end
 	vim.cmd(scroll(data, scroll_window, scroll_cursor))
 	-- Correct for wrapped lines
-	if scroll_cursor and scroll_window then
-		local lines_behind = math.abs(vim.fn.winline() - cursor_win_line)
-		if lines_behind > 0 then
-			vim.cmd(scroll(data, false, scroll_cursor, lines_behind))
-		end
-	elseif curpos_line_before == vim.fn.getcurpos()[2] then
+	local lines_behind = math.abs(vim.fn.winline() - cursor_win_line)
+	if scroll_cursor and scroll_window and lines_behind > 0 then
+		vim.cmd(scroll(data, false, scroll_cursor, lines_behind))
+	end
+	if curpos_line_before == vim.fn.getcurpos()[2] then
 		-- if curpos_line didn't change, we can use it to get scrolled_lines
 		-- This is more accurate when some lines are wrapped
 		scrolled_lines = winline_before - vim.fn.winline()

--- a/lua/neoscroll/utils.lua
+++ b/lua/neoscroll/utils.lua
@@ -62,15 +62,15 @@ end
 
 -- Hide/unhide cursor during scrolling for a better visual effect
 function utils.hide_cursor()
-  if vim.o.termguicolors and vim.o.guicursor ~= "" then
-    utils.guicursor = vim.o.guicursor
-    vim.o.guicursor = "a:NeoscrollHiddenCursor"
-  end
+	if vim.o.termguicolors and vim.o.guicursor ~= "" then
+		utils.guicursor = vim.o.guicursor
+		vim.o.guicursor = "a:NeoscrollHiddenCursor"
+	end
 end
 function utils.unhide_cursor()
-  if vim.o.guicursor == "a:NeoscrollHiddenCursor" then
-    vim.o.guicursor = utils.guicursor
-  end
+	if vim.o.guicursor == "a:NeoscrollHiddenCursor" then
+		vim.o.guicursor = utils.guicursor
+	end
 end
 
 -- Transforms fraction of window to number of lines


### PR DESCRIPTION
When there's wrapped line, sometimes scroll_one_line scroll more than one graphical line, this causes relative_line to be recorded wrong.

This means that if you're dealing with files with a lot of very long lines, typing zz scrolls more than it should. Sometimes no matter how many times you type zz you never get the cursor to center, it simply oscillate as it overshoots every time.

https://user-images.githubusercontent.com/38484873/211141016-90bfed28-aad6-49f8-8df3-7fda85066b56.mp4

This PR fixes that:

https://user-images.githubusercontent.com/38484873/211141059-82d2530a-017b-44b9-b293-fafb739f2aaa.mp4