### PR TITLE
doc: default setting missing comma in the attribute

### DIFF
--- a/doc/neoscroll.txt
+++ b/doc/neoscroll.txt
@@ -39,7 +39,7 @@ neoscroll.setup({opts})                                       *neoscroll-setup()
           hide_cursor = true,
           stop_eof = true,
           respect_scrolloff = false,
-          cursor_scrolls_alone = true
+          cursor_scrolls_alone = true,
           easing = 'linear',
           pre_hook = nil,
           post_hook = nil,


### PR DESCRIPTION
noticed missing comma after copy-pasting from the doc