### PR TITLE
docs: use opts instead of config to setup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ You will need neovim 0.5 for this plugin to work. Install it using your favorite
     ```lua
     return {
       "karb94/neoscroll.nvim",
-      config = function ()
-        require('neoscroll').setup({})
-      end
+      opts = {},
     }
     ```
 


### PR DESCRIPTION
Using the config method to set up plugins is considered bad practice when using lazy.nvim.

lazy.nvim docs states:
```
Always use opts instead of config when possible. config is almost never needed.
```