### PR TITLE
fix: many typos

### DIFF
--- a/doc/neoscroll.txt
+++ b/doc/neoscroll.txt
@@ -188,7 +188,7 @@ COMMANDS                                                     *neoscroll-commands
 |NeoscrollEnableBufferPM| / |NeoscrollDisableBufferPM|
     Enable/disable "Performance Mode" for the current buffer.
 
-|NeoscrollEnableGlobalPM| / |NeoscrollDisablGlobalePM|
+|NeoscrollEnableGlobalPM| / |NeoscrollDisableGlobalePM|
     Enable/disable "Performance Mode" for all buffers.
 
 

--- a/doc/neoscroll.txt
+++ b/doc/neoscroll.txt
@@ -87,7 +87,7 @@ neoscroll.scroll({lines}, {opts})                            *neoscroll.scroll()
               function names.
           • {info} (type: `table`)
               Optional parameter that will be passed to the |pre_hook| and
-              |post_hook| functions. Useful to differenciate different
+              |post_hook| functions. Useful to differentiate different
               scrolling animations or to pass additional information to the
               hook functions.
           • {winid} (type: `integer`)
@@ -136,7 +136,7 @@ neoscroll.{ctrl_u, ctrl_d, ctrl_b, ctrl_f}({opts})
               function names.
           • {info} (type: `table`)
               Optional parameter that will be passed to the |pre_hook| and
-              |post_hook| functions. Useful to differenciate different
+              |post_hook| functions. Useful to differentiate different
               scrolling animations or to pass additional information to the
               hook functions.
           • {winid} (type: `integer`)
@@ -168,7 +168,7 @@ neoscroll.{zt,zz,zb}({opts})
               function names.
           • {info} (type: `table`)
               Optional parameter that will be passed to the |pre_hook| and
-              |post_hook| functions. Useful to differenciate different
+              |post_hook| functions. Useful to differentiate different
               scrolling animations or to pass additional information to the
               hook functions.
           • {winid} (type: `integer`)

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -90,7 +90,7 @@ neoscroll.signature_warning = true
 
 ---@param lines number
 ---@param move_cursor boolean | nil | table Scroll the window and the cursor simultaneously
----@param duration number | nil Duration of the animation in miliseconds
+---@param duration number | nil Duration of the animation in milliseconds
 ---@param easing string | nil Easing function to smooth the animation
 ---@param info table | nil
 ---@param winid integer | nil ID of the window to scroll
@@ -121,7 +121,7 @@ end
 
 ---@class ScrollOpts
 ---@field move_cursor boolean | nil Scroll the window and the cursor simultaneously
----@field duration number | nil Duration of the animation in miliseconds
+---@field duration number | nil Duration of the animation in milliseconds
 ---@field easing string | nil Easing function to smooth the animation
 ---@field info table | nil
 ---@field winid integer | nil ID of the window to scroll
@@ -235,7 +235,7 @@ function neoscroll.ctrl_f(opts)
 end
 
 ---@class Zopts
----@field half_win_duration number Duration of the animation in miliseconds
+---@field half_win_duration number Duration of the animation in milliseconds
 ---@field easing string | nil Easing function to smooth the animation
 ---@field info table | nil
 ---@field winid integer | nil ID of the window to scroll

--- a/lua/neoscroll/init.lua
+++ b/lua/neoscroll/init.lua
@@ -468,6 +468,8 @@ function neoscroll.setup(custom_opts)
   vim.cmd("command! NeoscrollEnableBufferPM let b:neoscroll_performance_mode = v:true")
   vim.cmd("command! NeoscrollDisableBufferPM let b:neoscroll_performance_mode = v:false")
   vim.cmd("command! NeoscrollEnableGlobalPM let g:neoscroll_performance_mode = v:true")
+  vim.cmd("command! NeoscrollDisableGlobalePM let g:neoscroll_performance_mode = v:false")
+  ---@type deprecated
   vim.cmd("command! NeoscrollDisablGlobalePM let g:neoscroll_performance_mode = v:false")
   if config.performance_mode then
     vim.g.neoscroll_performance_mode = true


### PR DESCRIPTION
Fix many typos.

Note: Changing the command name could affect existing users, so we added a new command