### PR TITLE
fix typo in install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ require('neoscroll').setup({
   stop_eof = true,             -- Stop at <EOF> when scrolling downwards
   respect_scrolloff = false,   -- Stop scrolling when the cursor reaches the scrolloff margin of the file
   cursor_scrolls_alone = true, -- The cursor will keep on scrolling even if the window cannot scroll further
-  duration_multiplier = 1.0    -- Global duration multiplier
+  duration_multiplier = 1.0,   -- Global duration multiplier
   easing = 'linear',           -- Default easing function
   pre_hook = nil,              -- Function to run before the scrolling animation starts
   post_hook = nil,             -- Function to run after the scrolling animation ends


### PR DESCRIPTION
There's just a small comma missing in the install options. 
Found out as I was pasting

Feel free to discard